### PR TITLE
Use embed for a single product code lookup result display

### DIFF
--- a/api/result.py
+++ b/api/result.py
@@ -4,7 +4,7 @@ ApiResult class
 
 from datetime import datetime
 from typing import Dict
-
+from discord import Embed
 from api import datetime_input_format, datetime_output_format, trim_string
 
 
@@ -13,24 +13,66 @@ class ApiResult(object):
     API Result object
     """
 
+    #taken from https://rpcs3.net/compatibility
+    STATUS_NOTHING = 0x455556
+    STATUS_LOADABLE = 0xe74c3c
+    STATUS_INTRO = 0xe08a1e
+    STATUS_INGAME = 0xf9b32f
+    STATUS_PLAYABLE = 0x1ebc61
+    STATUS_UNKNOWN = 0x3198ff
+
+    status_map = dict({
+        "Nothing": STATUS_NOTHING,
+        "Loadable": STATUS_LOADABLE,
+        "Intro": STATUS_INTRO,
+        "Ingame": STATUS_INGAME,
+        "Playable": STATUS_PLAYABLE
+    })
+
     def __init__(self, game_id: str, data: Dict) -> None:
         self.game_id = game_id
-        self.title = data["title"]
-        self.status = data["status"]
-        self.date = datetime.strptime(data["date"], datetime_input_format)
-        self.thread = data["thread"]
-        self.commit = data["commit"]
-        self.pr = data["pr"]
+        self.title = data["title"] if "title" in data else None
+        self.status = data["status"] if "status" in data else None
+        self.date = datetime.strptime(data["date"], datetime_input_format) if "date" in data else None
+        self.thread = data["thread"] if "thread" in data else None
+        self.commit = data["commit"] if "commit" in data else None
+        self.pr = data["pr"] if "pr" in data and data["pr"] is not 0 else """¯\_(ツ)_/¯"""
 
     def to_string(self) -> str:
         """
         Makes a string representation of the object.
         :return: string representation of the object
         """
-        return ("ID:{:9s} Title:{:40s} PR:{:4s} Status:{:8s} Updated:{:10s}".format(
-            self.game_id,
-            trim_string(self.title, 40),
-            self.pr if self.pr is not 0 else "????",
-            self.status,
-            datetime.strftime(self.date, datetime_output_format)
-        ))
+        if self.status in self.status_map:
+            return ("ID:{:9s} Title:{:40s} PR:{:4s} Status:{:8s} Updated:{:10s}".format(
+                self.game_id,
+                trim_string(self.title, 40),
+                self.pr,
+                self.status,
+                datetime.strftime(self.date, datetime_output_format)
+            ))
+        else:
+            return "Product code {} was not found in compatibility database, possibly untested!".format(self.game_id)
+
+    def to_embed(self) -> Embed:
+        """
+        Makes an Embed representation of the object.
+        :return: Embed representation of the object
+        """
+        if self.status in self.status_map:
+            return Embed(
+                title="[{}] {}".format(self.game_id, trim_string(self.title, 200)),
+                url="https://forums.rpcs3.net/thread-{}.html".format(self.thread),
+                color=self.status_map[self.status],
+            ).set_footer(
+                text="Status: {}, PR: {}, Updated: {}".format(
+                    self.status,
+                    self.pr,
+                    datetime.strftime(self.date, datetime_output_format)
+                )
+            )
+        else:
+            return Embed(
+                description="Product code {} was not found in compatibility database, possibly untested!".format(self.game_id),
+                color=self.STATUS_UNKNOWN
+            )

--- a/bot.py
+++ b/bot.py
@@ -92,10 +92,7 @@ async def on_message(message: Message):
     if len(code_list) > 0:
         for code in code_list:
             info = get_code(code)
-            if info is not None:
-                await message.channel.send('```{}```'.format(info))
-            else:
-                await message.channel.send('```Serial not found in compatibility database, possibly untested!```')
+            await message.channel.send(embed=info.to_embed())
         return
 
     # Log Analysis!

--- a/bot_utils.py
+++ b/bot_utils.py
@@ -1,7 +1,7 @@
 from api.request import ApiRequest
+from api.result import ApiResult
 
-
-def get_code(code: str) -> str:
+def get_code(code: str) -> ApiResult:
     """
     Gets the game data for a certain game code or returns None
     :param code: code to get data for
@@ -11,5 +11,5 @@ def get_code(code: str) -> str:
     if len(result.results) >= 1:
         for result in result.results:
             if result.game_id == code:
-                return result.to_string()
-    return None
+                return result
+    return ApiResult(code, dict({"status": "Unknown"}))

--- a/log_analyzer.py
+++ b/log_analyzer.py
@@ -27,9 +27,8 @@ class LogAnalyzer(object):
     def get_id(self):
         try:
             info = get_code(re.search(SERIAL_PATTERN, self.buffer).group('id'))
-            if info is not None:
-                self.report = info + '\n' + self.report
-                return self.ERROR_SUCCESS
+            self.report = info.to_string() + '\n' + self.report
+            return self.ERROR_SUCCESS
         except AttributeError:
             print("Could not detect serial! Aborting!")
             return self.ERROR_FAIL


### PR DESCRIPTION
This will only change the display of single code queries from regular messages, not `!compat` searches

Examples:
![image](https://user-images.githubusercontent.com/36445/36847779-3115eb90-1d81-11e8-98ca-0a9ee956cd13.png)
![image](https://user-images.githubusercontent.com/36445/36847788-37e65f22-1d81-11e8-973b-d1cf2cddf8db.png)

