### PR TITLE
"Disabled" too long, breaks embed alignment

### DIFF
--- a/log_analyzer.py
+++ b/log_analyzer.py
@@ -156,7 +156,7 @@ class LogAnalyzer(object):
                         if group_args['af_override'] == '0':
                             group_args['af_override'] = 'auto'
                         elif group_args['af_override'] == '1':
-                            group_args['af_override'] = 'disabled'
+                            group_args['af_override'] = 'off'
                     self.parsed_data.update(group_args)
             except AttributeError as ae:
                 print(ae)


### PR DESCRIPTION
Fix the following by shortening the text:
![image](https://user-images.githubusercontent.com/462484/38090466-5d414f5c-336b-11e8-8a79-d59da58a924d.png)
