### PR TITLE
Do not fail when reporting empty messages with logs attached

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -201,8 +201,13 @@ async def report(reason: str, message: Message, reporters: List[Member], attenti
 	channel: TextChannel = message.channel
 	user: User = author._user
 	offending_content = message.content
-	if (offending_content is None or offending_content == ""):
-		offending_content = "📎 message attachment (probably log)" if len(message.attachments) > 0 else "🤔 something fishy is going on here"
+	if len(message.attachments) > 0:
+		if (offending_content is not None and offending_content != ""):
+			offending_content += "\n"
+		for att in message.attachments:
+			offending_content += "\n📎 " + att.filename
+	if (offending_content is not None and offending_content != ""):
+		offending_content = "🤔 something fishy is going on here, there was no message or attachment"
 	e = Embed(
 		title="Report for {}".format(reason),
 		description="Not deleted/requires attention: @here" if attention else "Deleted/Doesn't require attention",

--- a/bot.py
+++ b/bot.py
@@ -200,6 +200,9 @@ async def report(reason: str, message: Message, reporters: List[Member], attenti
 	author: Member = message.author
 	channel: TextChannel = message.channel
 	user: User = author._user
+	offending_content = message.content
+	if (offending_content is None or offending_content == ""):
+		offending_content = "📎 message attachment (probably log)" if len(message.attachments) > 0 else "🤔 something fishy is going on here"
 	e = Embed(
 		title="Report for {}".format(reason),
 		description="Not deleted/requires attention: @here" if attention else "Deleted/Doesn't require attention",
@@ -208,7 +211,7 @@ async def report(reason: str, message: Message, reporters: List[Member], attenti
 	e.add_field(name="Violator", value=message.author.mention)
 	e.add_field(name="Channel", value=channel.mention)
 	e.add_field(name="Time", value=message.created_at)
-	e.add_field(name="Contents of offending item", value=message.content, inline=False)
+	e.add_field(name="Contents of offending item", value=offending_content, inline=False)
 	e.add_field(
 		name="Search query (since discord doesnt allow jump links <:panda_face:436991868547366913>)",
 		value="`from: {nick} during: {date} in: {channel} {text}`".format(

--- a/bot.py
+++ b/bot.py
@@ -206,7 +206,7 @@ async def report(reason: str, message: Message, reporters: List[Member], attenti
 			offending_content += "\n"
 		for att in message.attachments:
 			offending_content += "\n📎 " + att.filename
-	if (offending_content is not None and offending_content != ""):
+	if (offending_content is None or offending_content == ""):
 		offending_content = "🤔 something fishy is going on here, there was no message or attachment"
 	e = Embed(
 		title="Report for {}".format(reason),


### PR DESCRIPTION
Embed field cannot be empty, so just mention that it was log