### PR TITLE
Implement !explain and general commands cleanup

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -872,6 +872,10 @@ async def list_warnings_for_user(ctx: Context, user: User):
     await list_warnings_for_user(ctx, user.id, user.display_name)
 
 async def list_warnings_for_user(ctx: Context, user_id: int, user_name: str):
+    if Warning.select().where(Warning.discord_id == user_id).count() == 0:
+        await ctx.send(user_name + " has no warnings, is a standup citizen, and a pillar of this community")
+        return
+        
     is_private = await is_private_channel(ctx, gay=False)
     buffer = 'Warning list for ' + sanitize_string(user_name) + ':\n```\n'
     for warning in Warning.select().where(Warning.discord_id == user_id):

--- a/bot.py
+++ b/bot.py
@@ -288,7 +288,7 @@ async def piracy_check(message: Message):
                     rules=rules_channel.mention
                 ))
             await report("Piracy", trigger, None, message, None, attention=False)
-            await add_warning_for_user(message.channel, message.author._user, bot.user.id,
+            await add_warning_for_user(message.channel, message.author.id, bot.user.id,
                                        'Pirated Phrase Mentioned',
                                        str(message.created_at) + ' - ' + message.content)
             return True
@@ -313,7 +313,7 @@ async def piracy_alert(message: Message, trigger: str, trigger_context: str):
             author=message.author.mention
         )
     )
-    await add_warning_for_user(message.channel, message.author._user, bot.user.id,
+    await add_warning_for_user(message.channel, message.author.id, bot.user.id,
                                'Pirated Release Detected',
                                str(message.created_at) + ' - ' + message.content + ' - ' + trigger)
 

--- a/bot.py
+++ b/bot.py
@@ -787,7 +787,7 @@ async def delete(ctx: Context, id: int):
 
 @bot.group()
 async def warn(ctx: Context):
-    """Command used to manage warnings."""
+    """Command used to manage warnings. USE: !warn @user reason"""
     if await is_mod(ctx):
         if ctx.invoked_subcommand is None:
             args = ctx.message.content.split(' ')[1:]

--- a/bot.py
+++ b/bot.py
@@ -74,14 +74,14 @@ async def on_ready():
     bot_log = bot.get_channel(bot_log_id)
     reaction_confirm = '👌'
     reaction_failed = '⛔'
-    reaction_deny = '👮‍'
+    reaction_deny = '👮'
     refresh_piracy_cache()
 
 async def react_with(ctx: Context, reaction: Emoji):
     try:
         await ctx.message.add_reaction(reaction)
-    except Exception:
-        pass
+    except Exception as e:
+        print("Couldn't add a reaction: " + str(e))
 
 @bot.event
 async def on_reaction_add(reaction: Reaction, user: User):

--- a/bot.py
+++ b/bot.py
@@ -33,6 +33,9 @@ bot_channel: TextChannel = None
 rules_channel: TextChannel = None
 bot_log: TextChannel = None
 
+reaction_confirm: Emoji = None
+reaction_deny: Emoji = None
+
 file_handlers = (
     {
         'ext': '.zip',
@@ -62,9 +65,13 @@ async def on_ready():
     global bot_channel
     global bot_log
     global rules_channel
+    global reaction_confirm
+    global reaction_deny
     bot_channel = bot.get_channel(bot_channel_id)
     rules_channel = bot.get_channel(bot_rules_channel_id)
     bot_log = bot.get_channel(bot_log_id)
+    reaction_confirm = '👌'
+    reaction_deny = '👮‍'
     refresh_piracy_cache()
 
 
@@ -503,9 +510,13 @@ async def is_sudo(ctx: Context):
         Moderator.discord_id == author.id, Moderator.sudoer == True
     )
     if sudo_user is not None:
-        print("User is sudoer, allowed!")
+        print("User " + author.display_name + " is sudoer, allowed!")
         return True
     else:
+        try:
+            await ctx.message.add_reaction(reaction_deny)
+        except:
+            pass
         await ctx.channel.send(
             "{mention} is not a sudoer, this incident will be reported!".format(mention=author.mention)
         )
@@ -519,12 +530,14 @@ async def is_mod(ctx: Context):
         Moderator.discord_id == author.id
     )
     if mod_user is not None:
-        print("User is moderator, allowed!")
+        print("User " + author.display_name + " is moderator, allowed!")
         return True
     else:
-        await ctx.channel.send(
-            "{mention} is not a mod, this incident will be reported!".format(mention=author.mention)
-        )
+        try:
+            await ctx.message.add_reaction(reaction_deny)
+        except:
+            pass
+        await ctx.channel.send("{mention} is not a mod, this incident will be reported!".format(mention=author.mention))
         return False
 
 
@@ -548,6 +561,7 @@ async def sudo(ctx: Context):
     """Sudo command group, used to manage moderators and sudoers."""
     if not await is_sudo(ctx):
         ctx.invoked_subcommand = None
+        return
     if ctx.invoked_subcommand is None:
         await ctx.send('Invalid !sudo command passed...')
 
@@ -777,7 +791,7 @@ async def warn(ctx: Context):
             user: User = bot.get_user(int(args[0][3:-1] if args[0][2] == '!' else args[0][2:-1]))
             reason: str = ' '.join(args[1:])
             if await add_warning_for_user(ctx, user, reason):
-                await ctx.message.add_reaction('👌')
+                await ctx.message.add_reaction(reaction_confirm)
             await list_warnings_for_user(ctx, user)
     else:
         ctx.invoked_subcommand = None

--- a/bot.py
+++ b/bot.py
@@ -9,7 +9,7 @@ from typing import List
 
 import requests
 from discord import Message, Member, TextChannel, DMChannel, Forbidden, Reaction, User, Role, Embed, Emoji
-from discord.ext.commands import Bot, Context, UserConverter
+from discord.ext.commands import Bot, Context, UserConverter, CommandError
 from discord.utils import get
 from requests import Response
 from peewee import fn
@@ -57,7 +57,7 @@ file_handlers = (
 )
 
 
-async def generic_error_handler(ctx: Context, error):
+async def generic_error_handler(ctx: Context, error: CommandError):
     await react_with(ctx, reaction_failed)
     await ctx.send(str(error))
 
@@ -834,7 +834,7 @@ async def warn(ctx: Context):
         ctx.invoked_subcommand = None
 
 
-async def add_warning_for_user(ctx, user_id, reporter_id, reason: str, full_reason: str = '') -> bool:
+async def add_warning_for_user(ctx: Context, user_id: int, reporter_id: int, reason: str, full_reason: str = '') -> bool:
     if reason is None:
         await ctx.send("A reason needs to be provided...")
         return False
@@ -974,7 +974,7 @@ async def add(ctx: Context):
 
 
 @add.error
-async def add_error(ctx: Context, error):
+async def add_error(ctx: Context, error: CommandError):
     await generic_error_handler(ctx, error)
 
 
@@ -1019,7 +1019,7 @@ async def update(ctx: Context):
 
 
 @update.error
-async def add_error(ctx: Context, error):
+async def add_error(ctx: Context, error: CommandError):
     await generic_error_handler(ctx, error)
 
 

--- a/database.py
+++ b/database.py
@@ -27,11 +27,15 @@ class Warning(BaseModel):
     full_reason = TextField()
 
 
+class Explanation(BaseModel):
+    keyword = TextField(unique=True)
+    text = TextField()
+
 def init():
     with db:
         with db.atomic() as tx:
             db.get_tables()
-            db.create_tables([Moderator, PiracyString, Warning])
+            db.create_tables([Moderator, PiracyString, Warning, Explanation])
             try:
                 Moderator.get(discord_id=bot_admin_id)
             except DoesNotExist:

--- a/database.py
+++ b/database.py
@@ -1,4 +1,5 @@
 from peewee import *
+from playhouse.migrate import *
 
 from bot_config import bot_admin_id
 
@@ -20,16 +21,39 @@ class PiracyString(BaseModel):
 
 
 class Warning(BaseModel):
-    discord_id = IntegerField()
+    discord_id = IntegerField(index=True)
+    issuer_id = IntegerField(default=0)
     reason = TextField()
     full_reason = TextField()
 
 
 def init():
     with db:
-        db.get_tables()
-        db.create_tables([Moderator, PiracyString, Warning])
+        with db.atomic() as tx:
+            db.get_tables()
+            db.create_tables([Moderator, PiracyString, Warning])
+            try:
+                Moderator.get(discord_id=bot_admin_id)
+            except DoesNotExist:
+                Moderator(discord_id=bot_admin_id, sudoer=True).save()
+            tx.commit()
+
+        migrator = SqliteMigrator(db)
         try:
-            Moderator.get(discord_id=bot_admin_id)
-        except DoesNotExist:
-            Moderator(discord_id=bot_admin_id, sudoer=True).save()
+            with db.atomic() as tx:
+                migrate(
+                    migrator.add_column('warning', 'issuer_id', IntegerField(default=0)),
+                )
+                tx.commit()
+                print("Updated [warning] columns")
+        except Exception:
+            tx.rollback()
+        try:
+            with db.atomic() as tx:
+                migrate(
+                    migrator.add_index('warning', ('discord_id',), False),
+                )
+            tx.commit()
+            print("Updated [warning] indices")
+        except Exception:
+            tx.rollback()


### PR DESCRIPTION
In this PR:
* implemented !explain command group (show, add, update, remove)
* implemented !warn list subcommand to show full list of users with warnings
* implemented !warn for any user, including unknown / banned / kicked users
* made it so users can check their own warnings (without details, even in DM)
* implemented retroactive starbucks check on bot startup
* updated warning db model to support tracking of who issued the warning
* added more reactions from bot on different commands