### PR TITLE
A new round of fixes

### DIFF
--- a/CompatBot/Commands/Explain.cs
+++ b/CompatBot/Commands/Explain.cs
@@ -172,7 +172,7 @@ namespace CompatBot.Commands
         }
 
 
-        [Command("remove"), Aliases("delete", "del"), RequiresBotModRole]
+        [Command("remove"), Aliases("delete", "del", "erase", "obliterate"), RequiresBotModRole]
         [Description("Removes an explanation from the definition list")]
         public async Task Remove(CommandContext ctx, [RemainingText, Description("Term to remove")] string term)
         {

--- a/CompatBot/Commands/Psn.Check.cs
+++ b/CompatBot/Commands/Psn.Check.cs
@@ -30,8 +30,9 @@ namespace CompatBot.Commands
                 }
 
                 var updateInfo = await Client.GetTitleUpdatesAsync(productId, Config.Cts.Token).ConfigureAwait(false);
-                var embed = await updateInfo.AsEmbedAsync(ctx.Client, productId).ConfigureAwait(false);
-                await ctx.RespondAsync(embed: embed).ConfigureAwait(false);
+                var embeds = await updateInfo.AsEmbedAsync(ctx.Client, productId).ConfigureAwait(false);
+                foreach(var embed in embeds)
+                    await ctx.RespondAsync(embed: embed).ConfigureAwait(false);
             }
         }
     }

--- a/CompatBot/Commands/Sudo.Bot.cs
+++ b/CompatBot/Commands/Sudo.Bot.cs
@@ -41,9 +41,9 @@ namespace CompatBot.Commands
                 }
             }
 
-            [Command("restart"), Aliases("update"), TriggersTyping]
-            [Description("Restarts bot and pulls newest commit")]
-            public async Task Restart(CommandContext ctx)
+            [Command("update"), Aliases("upgrade", "restart", "reboot", "pull"), TriggersTyping]
+            [Description("Restarts bot and pulls the newest commit")]
+            public async Task Update(CommandContext ctx)
             {
                 if (lockObj.Wait(0))
                 {

--- a/CompatBot/Config.cs
+++ b/CompatBot/Config.cs
@@ -27,6 +27,7 @@ namespace CompatBot
 
         public static readonly CancellationTokenSource Cts = new CancellationTokenSource();
         public static readonly TimeSpan DefaultTimeout = TimeSpan.FromSeconds(30);
+        public static readonly TimeSpan LogParsingTimeout = TimeSpan.FromSeconds(15);
 
         public static class Colors
         {

--- a/CompatBot/EventHandlers/BotShutupHandler.cs
+++ b/CompatBot/EventHandlers/BotShutupHandler.cs
@@ -10,7 +10,10 @@ namespace CompatBot.EventHandlers
 {
     internal static class BotShutupHandler
     {
-        private static readonly AhoCorasickDoubleArrayTrie<string> ChillCheck = new AhoCorasickDoubleArrayTrie<string>(new[] { "shut the fuck up", "shut up", "shutup", "hush", "chill" }.ToDictionary(s => s, s => s), true);
+        private static readonly AhoCorasickDoubleArrayTrie<string> ChillCheck = new AhoCorasickDoubleArrayTrie<string>(new[]
+        {
+            "shut the fuck up", "shut up", "shutup", "hush", "chill", "take that back", "delete this", "bad bot",
+        }.ToDictionary(s => s, s => s), true);
 
         public static async Task OnMessageCreated(MessageCreateEventArgs args)
         {

--- a/CompatBot/EventHandlers/LogInfoHandler.cs
+++ b/CompatBot/EventHandlers/LogInfoHandler.cs
@@ -11,7 +11,6 @@ using CompatBot.EventHandlers.LogParsing.SourceHandlers;
 using CompatBot.Utils;
 using CompatBot.Utils.ResultFormatters;
 using DSharpPlus;
-using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
 
 namespace CompatBot.EventHandlers

--- a/CompatBot/EventHandlers/LogInfoHandler.cs
+++ b/CompatBot/EventHandlers/LogInfoHandler.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Diagnostics;
 using System.IO.Pipelines;
 using System.Linq;
 using System.Threading;
@@ -57,6 +58,7 @@ namespace CompatBot.EventHandlers
             }
 
             bool parsedLog = false;
+            var startTime = Stopwatch.StartNew();
             try
             {
                 foreach (var attachment in message.Attachments.Where(a => a.FileSize < Config.AttachmentSizeLimit))
@@ -139,7 +141,7 @@ namespace CompatBot.EventHandlers
             {
                 QueueLimiter.Release();
                 if (parsedLog)
-                    Console.WriteLine($"<<<<<<< {message.Id % 100} Finished parsing");
+                    Console.WriteLine($"<<<<<<< {message.Id % 100} Finished parsing in {startTime.Elapsed}");
             }
         }
     }

--- a/CompatBot/EventHandlers/LogParsing/LogParser.LogSections.cs
+++ b/CompatBot/EventHandlers/LogParsing/LogParser.LogSections.cs
@@ -109,6 +109,7 @@ namespace CompatBot.EventHandlers.LogParsing
                     ["F "] = new Regex(@"F \d+:\d+:\d+\.\d+ {.+?} (?<fatal_error>.*?(\:\W*\r?\n\(.*?)*)\r?$", DefaultOptions),
                     ["Failed to load RAP file:"] = new Regex(@"Failed to load RAP file: (?<rap_file>.*?)\r?$", DefaultOptions),
                     ["Rap file not found:"] = new Regex(@"Rap file not found: (?<rap_file>.*?)\r?$", DefaultOptions),
+                    ["Pad handler expected but none initialized"] = new Regex(@"(?<native_ui_input>Pad handler expected but none initialized).*?\r?$", DefaultOptions),
                 },
                 OnSectionEnd = MarkAsCompleteAndReset,
                 EndTrigger = "All threads stopped...",

--- a/CompatBot/Utils/EmbedPager.cs
+++ b/CompatBot/Utils/EmbedPager.cs
@@ -8,9 +8,9 @@ namespace CompatBot.Utils
 {
     internal class EmbedPager
     {
-        private const int MaxFieldLength = 1024;
-        private const int MaxTitleSize = 256;
-        private const int MaxFields = 25;
+        public const int MaxFieldLength = 1024;
+        public const int MaxTitleSize = 256;
+        public const int MaxFields = 25;
 
         public IEnumerable<DiscordEmbed> BreakInEmbeds(DiscordEmbedBuilder builder, IEnumerable<string> lines, int maxLinesPerField = 10)
         {

--- a/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.cs
+++ b/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.cs
@@ -228,6 +228,8 @@ namespace CompatBot.Utils.ResultFormatters
                 notes.AppendLine("Resolution was changed from recommended `1280x720`");
             if (!string.IsNullOrEmpty(items["hdd_game_path"]) && (items["serial"]?.StartsWith("BL", StringComparison.InvariantCultureIgnoreCase) ?? false))
                 notes.AppendLine($"Disc game inside `{items["hdd_game_path"]}`");
+            if (!string.IsNullOrEmpty(items["native_ui_input"]))
+                notes.AppendLine("Pad initialization problem detected. Try disabling Native UI.");
             if (state.Error == LogParseState.ErrorCode.SizeLimit)
                 notes.AppendLine("Log was too large, showing last processed run");
 

--- a/CompatBot/Utils/ResultFormatters/TitlePatchFormatter.cs
+++ b/CompatBot/Utils/ResultFormatters/TitlePatchFormatter.cs
@@ -60,7 +60,7 @@ namespace CompatBot.Utils.ResultFormatters
             }
             else
                 embedBuilder.Description = "No updates were found";
-            if (embedBuilder.Fields.Count > 0)
+            if (!result.Any() || embedBuilder.Fields.Any())
                 result.Add(embedBuilder.Build());
             return result;
         }


### PR DESCRIPTION
* Fix updates check for games that have more than 25 patches available, thanks, GT5.
* Limit log parsing time to 15 seconds tops.
* Add another detection to the log parser for pad initialization issue with native ui.