### PR TITLE
Show driver version for vulkan renderer

### DIFF
--- a/CompatBot/Commands/Psn.Check.cs
+++ b/CompatBot/Commands/Psn.Check.cs
@@ -46,7 +46,7 @@ namespace CompatBot.Commands
                     return;
                 }
 
-                var matches = PsnScraper.ContentIdMatcher.Matches(contentIds);
+                var matches = PsnScraper.ContentIdMatcher.Matches(contentIds.ToUpperInvariant());
                 var itemsToCheck = matches.Select(m => m.Groups["content_id"].Value).ToList();
                 if (itemsToCheck.Count == 0)
                 {

--- a/CompatBot/Commands/Psn.cs
+++ b/CompatBot/Commands/Psn.cs
@@ -34,6 +34,20 @@ namespace CompatBot.Commands
             await ctx.RespondAsync($"Removed {linksToRemove.Count} cached links").ConfigureAwait(false);
         }
 
+        [Command("rescan"), RequiresBotModRole]
+        [Description("Forces a full PSN rescan")]
+        public async Task Rescan(CommandContext ctx)
+        {
+            using (var db = new ThumbnailDb())
+            {
+                var items = db.State.ToList();
+                foreach (var state in items)
+                    state.Timestamp = 0;
+                await db.SaveChangesAsync(Config.Cts.Token).ConfigureAwait(false);
+            }
+            await ctx.ReactWithAsync(Config.Reactions.Success, "Reset state timestamps").ConfigureAwait(false);
+        }
+
         private static async Task TryDeleteThumbnailCache(CommandContext ctx, List<(string contentId, string link)> linksToRemove)
         {
             var contentIds = linksToRemove.ToDictionary(l => l.contentId, l => l.link);

--- a/CompatBot/Database/Providers/AmdDriverVersionProvider.cs
+++ b/CompatBot/Database/Providers/AmdDriverVersionProvider.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Xml.Linq;
+using CompatApiClient.Compression;
+
+namespace CompatBot.Database.Providers
+{
+    internal static class AmdDriverVersionProvider
+    {
+        private static readonly Dictionary<string, List<string>> VulkanToDriver = new Dictionary<string, List<string>>();
+        private static readonly Dictionary<string, string> OpenglToDriver = new Dictionary<string, string>();
+        private static readonly SemaphoreSlim SyncObj = new SemaphoreSlim(1, 1);
+
+        public static async Task RefreshAsync()
+        {
+            if (SyncObj.Wait(0))
+                try
+                {
+                    using (var httpClient = HttpClientFactory.Create(new CompressionMessageHandler()))
+                    using (var response = await httpClient.GetStreamAsync("https://raw.githubusercontent.com/GPUOpen-Drivers/amd-vulkan-versions/master/amdversions.xml").ConfigureAwait(false))
+                    {
+                        var xml = await XDocument.LoadAsync(response, LoadOptions.None, Config.Cts.Token).ConfigureAwait(false);
+                        foreach (var driver in xml.Root.Elements("driver"))
+                        {
+                            var winVer = (string)driver.Element("windows-version");
+                            var vkVer = (string)driver.Element("vulkan-version");
+                            var driverVer = (string)driver.Attribute("version");
+                            if (!VulkanToDriver.TryGetValue(vkVer, out var verList))
+                                VulkanToDriver[vkVer] = (verList = new List<string>());
+                            verList.Insert(0, driverVer);
+                            OpenglToDriver[winVer] = driverVer;
+                        }
+                    }
+                    foreach (var key in VulkanToDriver.Keys.ToList())
+                        VulkanToDriver[key] = VulkanToDriver[key].Distinct().ToList();
+                }
+                catch (Exception e)
+                {
+                    Console.WriteLine(e);
+                }
+                finally
+                {
+                    SyncObj.Release();
+                }
+        }
+
+        public static string GetFromOpengl(string openglVersion)
+        {
+            if (OpenglToDriver.TryGetValue(openglVersion, out var result) && result != null)
+                return result;
+            return openglVersion;
+        }
+
+        public static async Task<string> GetFromVulkanAsync(string vulkanVersion)
+        {
+            if (!VulkanToDriver.TryGetValue(vulkanVersion, out var result))
+                await RefreshAsync().ConfigureAwait(false);
+
+            if (result?.Count > 0 || (VulkanToDriver.TryGetValue(vulkanVersion, out result) && result.Count > 0))
+            {
+                if (result.Count == 1)
+                    return result[0];
+                return $"{result.First()} - {result.Last()}";
+            }
+
+            if (Version.TryParse(vulkanVersion, out var vkVer))
+            {
+                var vkVersions = new List<(Version v, string vv)>(VulkanToDriver.Count);
+                foreach (var key in VulkanToDriver.Keys)
+                {
+                    if (Version.TryParse(key, out var ver))
+                        vkVersions.Add((ver, VulkanToDriver[key].First()));
+                }
+                if (vkVersions.Count == 0)
+                    return vulkanVersion;
+
+                vkVersions.Sort((l, r) => l.v < r.v ? -1 : l.v > r.v ? 1 : 0);
+                if (vkVer < vkVersions[0].v)
+                    return $"older than {vkVersions[0].vv}";
+
+                var newest = vkVersions.Last();
+                if (vkVer > newest.v)
+                    return $"newer than {newest.vv}";
+            }
+
+            return vulkanVersion;
+        }
+    }
+}

--- a/CompatBot/EventHandlers/LogParsing/LogParser.LogSections.cs
+++ b/CompatBot/EventHandlers/LogParsing/LogParser.LogSections.cs
@@ -38,6 +38,7 @@ namespace CompatBot.EventHandlers.LogParsing
             {
                 Extractors = new Dictionary<string, Regex>
                 {
+                    ["RSX:"] = new Regex(@"Physical device intialized\. GPU=(?<vulkan_gpu>.+), driver=(?<vulkan_driver_version_raw>-?\d+)\r?$", DefaultOptions),
                     ["Serial:"] = new Regex(@"Serial: (?<serial>[A-z]{4}\d{5})\r?$", DefaultOptions),
                     ["Path:"] = new Regex(@"Path: ((?<win_path>\w:/)|(?<lin_path>/[^/]))(.*(?<hdd_game_path>/dev_hdd0/game/.*)/USRDIR.*?|.*?)\r?$", DefaultOptions),
                     ["custom config:"] = new Regex("custom config: (?<custom_config>.*?)\r?$", DefaultOptions),
@@ -106,6 +107,9 @@ namespace CompatBot.EventHandlers.LogParsing
                     ["GL RENDERER:"] = new Regex(@"GL RENDERER: (?<driver_manuf_new>.*?)\r?\n", DefaultOptions),
                     ["GL VERSION:"] = new Regex(@"GL VERSION:(\d|\.|\s|\w|-)* (?<driver_version_new>(\d+\.)*\d+)\r?\n", DefaultOptions),
                     ["texel buffer size reported:"] = new Regex(@"RSX: Supported texel buffer size reported: (?<texel_buffer_size_new>\d*?) bytes", DefaultOptions),
+                    ["Physical device intialized"] = new Regex(@"Physical device intialized\. GPU=(?<vulkan_gpu>.+), driver=(?<vulkan_driver_version_raw>-?\d+)\r?$", DefaultOptions),
+                    ["Found vulkan-compatible GPU:"] = new Regex(@"Found vulkan-compatible GPU: (?<vulkan_found_device>.+)\r?$", DefaultOptions),
+                    ["Renderer initialized on device"] = new Regex(@"Renderer initialized on device '(?<vulkan_initialized_device>.+)'\r?$", DefaultOptions),
                     ["F "] = new Regex(@"F \d+:\d+:\d+\.\d+ {.+?} (?<fatal_error>.*?(\:\W*\r?\n\(.*?)*)\r?$", DefaultOptions),
                     ["Failed to load RAP file:"] = new Regex(@"Failed to load RAP file: (?<rap_file>.*?)\r?$", DefaultOptions),
                     ["Rap file not found:"] = new Regex(@"Rap file not found: (?<rap_file>.*?)\r?$", DefaultOptions),

--- a/CompatBot/EventHandlers/LogParsing/LogParser.StateMachineGenerator.cs
+++ b/CompatBot/EventHandlers/LogParsing/LogParser.StateMachineGenerator.cs
@@ -53,7 +53,7 @@ namespace CompatBot.EventHandlers.LogParsing
 #if DEBUG
                     Console.WriteLine($"regex {group.Name} = {group.Value}");
 #endif
-                    if (group.Name == "rap_file")
+                    if (group.Name == "rap_file" || group.Name == "vulkan_found_device")
                     {
                         var currentValue = state.WipCollection[group.Name];
                         if (!string.IsNullOrEmpty(currentValue))

--- a/CompatBot/Program.cs
+++ b/CompatBot/Program.cs
@@ -4,6 +4,7 @@ using System.Threading.Tasks;
 using CompatBot.Commands;
 using CompatBot.Commands.Converters;
 using CompatBot.Database;
+using CompatBot.Database.Providers;
 using CompatBot.EventHandlers;
 using CompatBot.ThumbScrapper;
 using DSharpPlus;
@@ -49,6 +50,7 @@ namespace CompatBot
                     Console.WriteLine("No token was specified.");
                     return;
                 }
+                var amdDriverRefreshTask = AmdDriverVersionProvider.RefreshAsync();
 
                 using (var db = new BotDb())
                     if (!await DbImporter.UpgradeAsync(db, Config.Cts.Token))
@@ -60,6 +62,7 @@ namespace CompatBot
 
                 var psnScrappingTask = new PsnScraper().RunAsync(Config.Cts.Token);
                 var gameTdbScrapingTask = GameTdbScraper.RunAsync(Config.Cts.Token);
+                await amdDriverRefreshTask.ConfigureAwait(false);
 
                 var config = new DiscordConfiguration
                 {

--- a/CompatBot/ThumbScrapper/GameTdbScraper.cs
+++ b/CompatBot/ThumbScrapper/GameTdbScraper.cs
@@ -39,7 +39,7 @@ namespace CompatBot.ThumbScrapper
                 {
                     PrintError(e);
                 }
-                await Task.Delay(TimeSpan.FromDays(30), cancellationToken).ConfigureAwait(false);
+                await Task.Delay(TimeSpan.FromDays(1), cancellationToken).ConfigureAwait(false);
             } while (!cancellationToken.IsCancellationRequested);
         }
 

--- a/CompatBot/ThumbScrapper/PsnScraper.cs
+++ b/CompatBot/ThumbScrapper/PsnScraper.cs
@@ -308,6 +308,7 @@ namespace CompatBot.ThumbScrapper
                     switch (item.Type)
                     {
                         case "game":
+                        case "game-related":
                             if (string.IsNullOrEmpty(item.Id))
                                 continue;
 


### PR DESCRIPTION
Thanks to additional logging from kd, we can now get the driver version from vulkan device information (still not as good as opengl for AMD cards).

Plus a couple of fixes for psn scraping