### PR TITLE
for some reason pipe reader decided to break on advance

### DIFF
--- a/CompatBot/CompatBot.csproj
+++ b/CompatBot/CompatBot.csproj
@@ -16,13 +16,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DSharpPlus" Version="4.0.0-beta-00508" />
-    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.0.0-beta-00508" />
+    <PackageReference Include="DSharpPlus" Version="4.0.0-beta-00513" />
+    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.0.0-beta-00513" />
     <PackageReference Include="MathParser.org-mXparser" Version="4.2.1" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.1.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.1.2" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="2.1.2" />
     <PackageReference Include="NReco.Text.AhoCorasickDoubleArrayTrie" Version="1.0.1" />
     <PackageReference Include="System.IO.Pipelines" Version="4.5.0" />
   </ItemGroup>

--- a/CompatBot/EventHandlers/LogParsing/LogParser.PipeReader.cs
+++ b/CompatBot/EventHandlers/LogParsing/LogParser.PipeReader.cs
@@ -66,7 +66,7 @@ namespace CompatBot.EventHandlers.LogParsing
                     await FlushAllLinesAsync(result.Buffer, currentSectionLines, state).ConfigureAwait(false);
                 var sectionStart = currentSectionLines.Count == 0 ? buffer : currentSectionLines.First.Value;
                 totalReadBytes += result.Buffer.Slice(0, sectionStart.Start).Length;
-                reader.AdvanceTo(sectionStart.Start, buffer.End);
+                reader.AdvanceTo(sectionStart.Start);
                 if (totalReadBytes >= Config.LogSizeLimit)
                 {
                     state.Error = LogParseState.ErrorCode.SizeLimit;


### PR DESCRIPTION
don't tell the pipe the examined position to fix this?
also updated some deps