### PR TITLE
Small changes to bot responses

### DIFF
--- a/CompatBot/EventHandlers/LogAsTextMonitor.cs
+++ b/CompatBot/EventHandlers/LogAsTextMonitor.cs
@@ -41,10 +41,10 @@ namespace CompatBot.EventHandlers
                 if (brokenDump)
                     await args.Channel.SendMessageAsync(
                         "Please follow the quickstart guide to get a proper dump of a digital title.\n" +
-                        "Also please upload full log file instead of pasting random bits that might or might not be relevant."
+                        "Also please upload the full RPCS3.log.gz (or RPCS3.log with a zip/rar icon) file after closing the emulator instead of pasting only a section which may be completely irrelevant."
                     ).ConfigureAwait(false);
                 else
-                    await args.Channel.SendMessageAsync($"{args.Message.Author.Mention} please upload the full log file instead of pasting some random bits that might be completely irrelevant.").ConfigureAwait(false);
+                    await args.Channel.SendMessageAsync($"{args.Message.Author.Mention} Please upload the full RPCS3.log.gz (or RPCS3.log with a zip/rar icon) file after closing the emulator instead of pasting only a section which may be completely irrelevant.").ConfigureAwait(false);
             }
         }
     }

--- a/CompatBot/EventHandlers/LogParsingHandler.cs
+++ b/CompatBot/EventHandlers/LogParsingHandler.cs
@@ -138,7 +138,7 @@ namespace CompatBot.EventHandlers
                     {
                         case "TXT":
                         {
-                            await args.Channel.SendMessageAsync($"{message.Author.Mention} Please upload the full RPCS3.log.gz (or RPCS3.log with a zip/rar icon) file after closing the emulator instead of copying the logs from RPCS3's interface. As it doesn't contain all the required information.).ConfigureAwait(false);
+                            await args.Channel.SendMessageAsync($"{message.Author.Mention} Please upload the full RPCS3.log.gz (or RPCS3.log with a zip/rar icon) file after closing the emulator instead of copying the logs from RPCS3's interface. As it doesn't contain all the required information.").ConfigureAwait(false);
                             return;
                         }
                     }

--- a/CompatBot/EventHandlers/LogParsingHandler.cs
+++ b/CompatBot/EventHandlers/LogParsingHandler.cs
@@ -138,7 +138,7 @@ namespace CompatBot.EventHandlers
                     {
                         case "TXT":
                         {
-                            await args.Channel.SendMessageAsync($"{message.Author.Mention} Please upload the full RPCS3.log.gz (or RPCS3.log with a zip/rar icon) file after closing the emulator instead of copying the logs from RPCS3's interface. As it doesn't contain all the required information.").ConfigureAwait(false);
+                            await args.Channel.SendMessageAsync($"{message.Author.Mention} Please upload the full RPCS3.log.gz (or RPCS3.log with a zip/rar icon) file after closing the emulator instead of copying the logs from RPCS3's interface, as it doesn't contain all the required information.").ConfigureAwait(false);
                             return;
                         }
                     }

--- a/CompatBot/EventHandlers/LogParsingHandler.cs
+++ b/CompatBot/EventHandlers/LogParsingHandler.cs
@@ -138,7 +138,7 @@ namespace CompatBot.EventHandlers
                     {
                         case "TXT":
                         {
-                            await args.Channel.SendMessageAsync($"{message.Author.Mention} please do not copy/paste logs from UI, they do not contain all the required information; ask if you do not know how to upload full log file").ConfigureAwait(false);
+                            await args.Channel.SendMessageAsync($"{message.Author.Mention} Please upload the full RPCS3.log.gz (or RPCS3.log with a zip/rar icon) file after closing the emulator instead of copying the logs from RPCS3's interface. As it doesn't contain all the required information.).ConfigureAwait(false);
                             return;
                         }
                     }


### PR DESCRIPTION
When a user posts an error from RPCS3's log or uploads a log in .txt format the bot will now respond with instructions on how to upload the full RPCS3.log.gz file. This will help stop some needless back and forth between users.