### PR TITLE
Make !explain update consistent

### DIFF
--- a/CompatBot/Commands/Explain.cs
+++ b/CompatBot/Commands/Explain.cs
@@ -189,7 +189,8 @@ namespace CompatBot.Commands
                     await ctx.ReactWithAsync(Config.Reactions.Failure, $"Term `{term}` is not defined").ConfigureAwait(false);
                 else
                 {
-                    item.Text = explanation ?? "";
+                    if (!string.IsNullOrEmpty(explanation))
+                        item.Text = explanation;
                     if (attachment?.Length > 0)
                     {
                         item.Attachment = attachment;


### PR DESCRIPTION
When update contains only text/image, keep current image/text respectively.
To remove one or another, use `!explain remove text/attachment`.