### PR TITLE
Mark command for deletion with the new `.` command prefix

### DIFF
--- a/CompatBot/Commands/Attributes/LimitedToHelpChannel.cs
+++ b/CompatBot/Commands/Attributes/LimitedToHelpChannel.cs
@@ -16,7 +16,7 @@ namespace CompatBot.Commands.Attributes
             if (ctx.Channel.Name.Equals("help", StringComparison.InvariantCultureIgnoreCase))
                 return true;
 
-            await ctx.RespondAsync($"`{Config.CommandPrefix}{ctx.Command.QualifiedName}` is limited to help channel and DMs").ConfigureAwait(false);
+            await ctx.RespondAsync($"`{ctx.Prefix}{ctx.Command.QualifiedName}` is limited to help channel and DMs").ConfigureAwait(false);
             return false;
         }
     }

--- a/CompatBot/Commands/Attributes/LimitedToSpamChannel.cs
+++ b/CompatBot/Commands/Attributes/LimitedToSpamChannel.cs
@@ -30,7 +30,7 @@ namespace CompatBot.Commands.Attributes
             catch {}
 
             var spamChannel = await ctx.Client.GetChannelAsync(Config.BotSpamId).ConfigureAwait(false);
-            await ctx.RespondAsync($"`{Config.CommandPrefix}{ctx.Command.QualifiedName}` is limited to {spamChannel.Mention} and DMs").ConfigureAwait(false);
+            await ctx.RespondAsync($"`{ctx.Prefix}{ctx.Command.QualifiedName}` is limited to {spamChannel.Mention} and DMs").ConfigureAwait(false);
             return false;
         }
 

--- a/CompatBot/Commands/BaseCommandModuleCustom.cs
+++ b/CompatBot/Commands/BaseCommandModuleCustom.cs
@@ -20,6 +20,14 @@ namespace CompatBot.Commands
 
         public override async Task BeforeExecutionAsync(CommandContext ctx)
         {
+            try
+            {
+                await ctx.Message.DeleteAsync().ConfigureAwait(false);
+            }
+            catch (Exception e)
+            {
+                Config.Log.Warn(e, "Failed to delete command message with the autodelete command prefix");
+            }
             var disabledCmds = DisabledCommandsProvider.Get();
             if (disabledCmds.Contains(ctx.Command.QualifiedName) && !disabledCmds.Contains("*"))
             {

--- a/CompatBot/Commands/Explain.cs
+++ b/CompatBot/Commands/Explain.cs
@@ -123,7 +123,7 @@ namespace CompatBot.Commands
                 var spamChannel = await ctx.Client.GetChannelAsync(Config.BotSpamId).ConfigureAwait(false);
                 inSpecificLocation = $" in {spamChannel.Mention} or bot DMs";
             }
-            var msg = $"Unknown term `{term.Sanitize()}`. Use `{Config.CommandPrefix}explain list` to look at defined terms{inSpecificLocation}";
+            var msg = $"Unknown term `{term.Sanitize()}`. Use `{ctx.Prefix}explain list` to look at defined terms{inSpecificLocation}";
             await ctx.RespondAsync(msg).ConfigureAwait(false);
         }
 

--- a/CompatBot/Commands/Sudo.Mod.cs
+++ b/CompatBot/Commands/Sudo.Mod.cs
@@ -23,7 +23,7 @@ namespace CompatBot.Commands
                 {
                     await ctx.ReactWithAsync(Config.Reactions.Success,
                         $"{user.Mention} was successfully added as moderator!\n" +
-                         $"Try using `{Config.CommandPrefix}help` to see new commands available to you"
+                         $"Try using `{ctx.Prefix}help` to see new commands available to you"
                     ).ConfigureAwait(false);
                 }
                 else

--- a/CompatBot/Config.cs
+++ b/CompatBot/Config.cs
@@ -14,6 +14,7 @@ namespace CompatBot
     internal static class Config
     {
         public static readonly string CommandPrefix = "!";
+        public static readonly string AutoRemoveCommandPrefix = ".";
         public static readonly ulong BotGuildId = 272035812277878785;         // discord server where the bot is supposed to be
         public static readonly ulong BotGeneralChannelId = 272035812277878785;// #rpcs3; main or general channel where noobs come first thing
         public static readonly ulong BotChannelId = 291679908067803136;       // #compatbot; this is used for !compat/!top results and new builds announcements

--- a/CompatBot/EventHandlers/AppveyorLinksHandler.cs
+++ b/CompatBot/EventHandlers/AppveyorLinksHandler.cs
@@ -21,10 +21,7 @@ namespace CompatBot.EventHandlers
 
         public static async Task OnMessageCreated(MessageCreateEventArgs args)
         {
-            if (args.Author.IsBot)
-                return;
-
-            if (string.IsNullOrEmpty(args.Message.Content) || args.Message.Content.StartsWith(Config.CommandPrefix))
+            if (DefaultHandlerFilter.IsFluff(args.Message))
                 return;
 
             var matches = BuildLinks.Matches(args.Message.Content);

--- a/CompatBot/EventHandlers/BotReactionsHandler.cs
+++ b/CompatBot/EventHandlers/BotReactionsHandler.cs
@@ -75,6 +75,9 @@ namespace CompatBot.EventHandlers
             if (DefaultHandlerFilter.IsFluff(args.Message))
                 return;
 
+            if (args.Message.Channel.IsPrivate)
+                return;
+
 #if DEBUG
             if (args.Message.Content == "emoji test")
             {

--- a/CompatBot/EventHandlers/GithubLinksHandler.cs
+++ b/CompatBot/EventHandlers/GithubLinksHandler.cs
@@ -18,10 +18,7 @@ namespace CompatBot.EventHandlers
 
         public static async Task OnMessageCreated(MessageCreateEventArgs args)
         {
-            if (args.Author.IsBot)
-                return;
-
-            if (string.IsNullOrEmpty(args.Message.Content) || args.Message.Content.StartsWith(Config.CommandPrefix))
+            if (DefaultHandlerFilter.IsFluff(args.Message))
                 return;
 
             var lastBotMessages = await args.Channel.GetMessagesBeforeAsync(args.Message.Id, 20, DateTime.UtcNow.AddSeconds(-30)).ConfigureAwait(false);

--- a/CompatBot/EventHandlers/IsTheGamePlayableHandler.cs
+++ b/CompatBot/EventHandlers/IsTheGamePlayableHandler.cs
@@ -30,7 +30,7 @@ namespace CompatBot.EventHandlers
 
         public static async Task OnMessageCreated(MessageCreateEventArgs args)
         {
-            if (args.Author.IsBot)
+            if (DefaultHandlerFilter.IsFluff(args.Message))
                 return;
 
 #if !DEBUG
@@ -41,9 +41,6 @@ namespace CompatBot.EventHandlers
 
             if (CooldownBuckets.TryGetValue(args.Channel.Id, out var lastCheck)
                 && DateTime.UtcNow - lastCheck < CooldownThreshold)
-                return;
-
-            if (string.IsNullOrEmpty(args.Message.Content) || args.Message.Content.StartsWith(Config.CommandPrefix))
                 return;
 
 #if !DEBUG

--- a/CompatBot/EventHandlers/LogAsTextMonitor.cs
+++ b/CompatBot/EventHandlers/LogAsTextMonitor.cs
@@ -14,10 +14,7 @@ namespace CompatBot.EventHandlers
 
         public static async Task OnMessageCreated(MessageCreateEventArgs args)
         {
-            if (args.Author.IsBot)
-                return;
-
-            if (string.IsNullOrEmpty(args.Message.Content) || args.Message.Content.StartsWith(Config.CommandPrefix))
+            if (DefaultHandlerFilter.IsFluff(args.Message))
                 return;
 
             if (!"help".Equals(args.Channel.Name, StringComparison.InvariantCultureIgnoreCase))

--- a/CompatBot/EventHandlers/LogParsingHandler.cs
+++ b/CompatBot/EventHandlers/LogParsingHandler.cs
@@ -41,11 +41,7 @@ namespace CompatBot.EventHandlers
 
         public static Task OnMessageCreated(MessageCreateEventArgs args)
         {
-            var message = args.Message;
-            if (message.Author.IsBot)
-                return Task.CompletedTask;
-
-            if (!string.IsNullOrEmpty(message.Content) && message.Content.StartsWith(Config.CommandPrefix))
+            if (DefaultHandlerFilter.IsFluff(args.Message))
                 return Task.CompletedTask;
 
             OnNewLog(args.Client, args.Channel, args.Message);

--- a/CompatBot/EventHandlers/PostLogHelpHandler.cs
+++ b/CompatBot/EventHandlers/PostLogHelpHandler.cs
@@ -20,7 +20,7 @@ namespace CompatBot.EventHandlers
 
         public static async Task OnMessageCreated(MessageCreateEventArgs args)
         {
-            if (args.Author.IsBot)
+            if (DefaultHandlerFilter.IsFluff(args.Message))
                 return;
 
 #if !DEBUG
@@ -30,9 +30,6 @@ namespace CompatBot.EventHandlers
             if (DateTime.UtcNow - lastMention < ThrottlingThreshold)
                 return;
 #endif
-
-            if (string.IsNullOrEmpty(args.Message.Content) || args.Message.Content.StartsWith(Config.CommandPrefix))
-                return;
 
             if (!UploadLogMention.IsMatch(args.Message.Content))
                 return;

--- a/CompatBot/EventHandlers/ProductCodeLookup.cs
+++ b/CompatBot/EventHandlers/ProductCodeLookup.cs
@@ -25,10 +25,7 @@ namespace CompatBot.EventHandlers
 
         public static async Task OnMessageCreated(MessageCreateEventArgs args)
         {
-            if (args.Author.IsBot)
-                return;
-
-            if (string.IsNullOrEmpty(args.Message.Content) || args.Message.Content.StartsWith(Config.CommandPrefix))
+            if (DefaultHandlerFilter.IsFluff(args.Message))
                 return;
 
             var lastBotMessages = await args.Channel.GetMessagesBeforeAsync(args.Message.Id, 20, DateTime.UtcNow.AddSeconds(-30)).ConfigureAwait(false);

--- a/CompatBot/EventHandlers/TableFlipMonitor.cs
+++ b/CompatBot/EventHandlers/TableFlipMonitor.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
+using CompatBot.Utils;
 using DSharpPlus.EventArgs;
 
 namespace CompatBot.EventHandlers
@@ -10,11 +11,7 @@ namespace CompatBot.EventHandlers
 
         public static async Task OnMessageCreated(MessageCreateEventArgs args)
         {
-            if (args.Author.IsBot)
-                return;
-
-            var content = args.Message.Content;
-            if (string.IsNullOrEmpty(content) || content.StartsWith(Config.CommandPrefix))
+            if (DefaultHandlerFilter.IsFluff(args.Message))
                 return;
 
             /*
@@ -33,6 +30,7 @@ namespace CompatBot.EventHandlers
              */
             try
             {
+                var content = args.Message.Content;
                 if (!(content.Contains("┻━┻") ||
                       content.Contains("┻━┻")))
                     return;

--- a/CompatBot/EventHandlers/UnknownCommandHandler.cs
+++ b/CompatBot/EventHandlers/UnknownCommandHandler.cs
@@ -15,6 +15,9 @@ namespace CompatBot.EventHandlers
     {
         public static async Task OnError(CommandErrorEventArgs e)
         {
+            if (e.Context.User.IsBot)
+                return;
+
             if (!(e.Exception is CommandNotFoundException cnfe))
             {
                 Config.Log.Error(e.Exception);
@@ -25,6 +28,7 @@ namespace CompatBot.EventHandlers
                 return;
 
             if (e.Context.Prefix != Config.CommandPrefix
+                && e.Context.Prefix != Config.AutoRemoveCommandPrefix
                 && (e.Context.Message.Content?.EndsWith("?") ?? false)
                 && e.Context.CommandsNext.RegisteredCommands.TryGetValue("8ball", out var cmd))
             {

--- a/CompatBot/Program.cs
+++ b/CompatBot/Program.cs
@@ -121,7 +121,7 @@ namespace CompatBot
                 {
                     var commands = client.UseCommandsNext(new CommandsNextConfiguration
                     {
-                        StringPrefixes = new[] {Config.CommandPrefix},
+                        StringPrefixes = new[] {Config.CommandPrefix, Config.AutoRemoveCommandPrefix},
                         Services = new ServiceCollection().BuildServiceProvider(),
                     });
                     commands.RegisterConverter(new CustomDiscordChannelConverter());

--- a/CompatBot/Utils/DefaultHandlerFilter.cs
+++ b/CompatBot/Utils/DefaultHandlerFilter.cs
@@ -6,13 +6,12 @@ namespace CompatBot.Utils
     {
         internal static bool IsFluff(DiscordMessage message)
         {
-            if (message.Channel.IsPrivate)
-                return true;
-
             if (message.Author.IsBot)
                 return true;
 
-            if (string.IsNullOrEmpty(message.Content) || message.Content.StartsWith(Config.CommandPrefix))
+            if (string.IsNullOrEmpty(message.Content)
+                || message.Content.StartsWith(Config.CommandPrefix)
+                || message.Content.StartsWith(Config.AutoRemoveCommandPrefix))
                 return true;
 
             return false;

--- a/CompatBot/Utils/DiscordClientExtensions.cs
+++ b/CompatBot/Utils/DiscordClientExtensions.cs
@@ -90,7 +90,7 @@ namespace CompatBot.Utils
 
         public static Task ReactWithAsync(this CommandContext ctx, DiscordEmoji emoji, string fallbackMessage = null, bool? showBoth = null)
         {
-            return ReactWithAsync(ctx.Message, ctx.Client, emoji, fallbackMessage, showBoth);
+            return ReactWithAsync(ctx.Message, ctx.Client, emoji, fallbackMessage, showBoth ?? (ctx.Prefix == Config.AutoRemoveCommandPrefix));
         }
 
         public static async Task<IReadOnlyCollection<DiscordMessage>> GetMessagesBeforeAsync(this DiscordChannel channel, ulong beforeMessageId, int limit = 100, DateTime? timeLimit = null)


### PR DESCRIPTION
Doesn't work for `.help`, that would require #148 