### PR TITLE
Implement official client for GitHub v3 endpoints

### DIFF
--- a/Clients/GithubClient/GithubClient.csproj
+++ b/Clients/GithubClient/GithubClient.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.0.0" />
+    <PackageReference Include="Octokit" Version="0.36.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Clients/GithubClient/POCOs/PrInfo.cs
+++ b/Clients/GithubClient/POCOs/PrInfo.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Octokit;
+using System;
 
 namespace GithubClient.POCOs
 {
@@ -19,6 +20,31 @@ namespace GithubClient.POCOs
         public int Deletions;
         public int ChangedFiles;
         public string Message;
+
+        public static implicit operator PrInfo(PullRequest pr)
+        {
+            if (pr == null)
+                return null;
+
+            return new PrInfo
+            {
+                HtmlUrl = pr.HtmlUrl,
+                Number = pr.Number,
+                State = pr.State.StringValue,
+                Title = pr.Title,
+                User = pr.User,
+                CreatedAt = pr.CreatedAt.UtcDateTime,
+                UpdatedAt = pr.UpdatedAt.UtcDateTime,
+                ClosedAt = pr.ClosedAt?.UtcDateTime,
+                MergedAt = pr.MergedAt?.UtcDateTime,
+                MergeCommitSha = pr.MergeCommitSha,
+                StatusesUrl = pr.StatusesUrl,
+                Additions = pr.Additions,
+                Deletions = pr.Deletions,
+                ChangedFiles = pr.ChangedFiles,
+                Message = pr.Body
+            };
+        }
     }
 
     public class IssueInfo
@@ -34,11 +60,43 @@ namespace GithubClient.POCOs
         public DateTime? MergedAt;
         public string Body;
         public PullRequestReference PullRequest;
+
+        public static implicit operator IssueInfo(Issue issue)
+        {
+            if (issue == null)
+                return null;
+
+            return new IssueInfo
+            {
+                HtmlUrl = issue.HtmlUrl,
+                Number = issue.Number,
+                State = issue.State.StringValue,
+                Title = issue.Title,
+                User = issue.User,
+                CreatedAt = issue.CreatedAt.UtcDateTime,
+                UpdatedAt = issue.UpdatedAt?.UtcDateTime,
+                ClosedAt = issue.ClosedAt?.UtcDateTime,
+                MergedAt = null,
+                Body = issue.Body,
+                PullRequest = issue.PullRequest
+            };
+        }
     }
 
     public class GithubUser
     {
         public string Login;
+
+        public static implicit operator GithubUser(User user)
+        {
+            if (user == null)
+                return null;
+
+            return new GithubUser
+            {
+                Login = user.Login
+            };
+        }
     }
 
     public class PullRequestReference
@@ -47,5 +105,19 @@ namespace GithubClient.POCOs
         public string HtmlUrl;
         public string DiffUrl;
         public string PatchUrl;
+
+        public static implicit operator PullRequestReference(PullRequest pr)
+        {
+            if (pr == null)
+                return null;
+
+            return new PullRequestReference
+            {
+                Url = pr.Url,
+                HtmlUrl = pr.HtmlUrl,
+                DiffUrl = pr.DiffUrl,
+                PatchUrl = pr.PatchUrl
+            };
+        }
     }
 }

--- a/CompatBot/Commands/Pr.cs
+++ b/CompatBot/Commands/Pr.cs
@@ -31,7 +31,7 @@ namespace CompatBot.Commands
         [GroupCommand]
         public async Task List(CommandContext ctx, [Description("Get information for PRs with specified text in description. First word might be an author"), RemainingText] string searchStr = null)
         {
-            var openPrList = await githubClient.GetOpenPrsAsync(Config.Cts.Token).ConfigureAwait(false);
+            var openPrList = await githubClient.GetOpenPrsAsync().ConfigureAwait(false);
             if (openPrList == null)
             {
                 await ctx.ReactWithAsync(Config.Reactions.Failure, "Couldn't retrieve open pull requests list, try again later").ConfigureAwait(false);
@@ -88,7 +88,7 @@ namespace CompatBot.Commands
 
         public static async Task LinkPrBuild(DiscordClient client, DiscordMessage message, int pr)
         {
-            var prInfo = await githubClient.GetPrInfoAsync(pr, Config.Cts.Token).ConfigureAwait(false);
+            var prInfo = await githubClient.GetPrInfoAsync(pr).ConfigureAwait(false);
             if (prInfo.Number == 0)
             {
                 await message.ReactWithAsync(Config.Reactions.Failure, prInfo.Message ?? "PR not found").ConfigureAwait(false);
@@ -148,7 +148,7 @@ namespace CompatBot.Commands
 
         public static async Task LinkIssue(DiscordClient client, DiscordMessage message, int issue)
         {
-            var issueInfo = await githubClient.GetIssueInfoAsync(issue, Config.Cts.Token).ConfigureAwait(false);
+            var issueInfo = await githubClient.GetIssueInfoAsync(issue).ConfigureAwait(false);
             if (issueInfo.Number == 0)
                 return;
 

--- a/CompatBot/Utils/ResultFormatters/UpdateInfoFormatter.cs
+++ b/CompatBot/Utils/ResultFormatters/UpdateInfoFormatter.cs
@@ -33,7 +33,7 @@ namespace CompatBot.Utils.ResultFormatters
             {
                 if (latestPr > 0)
                 {
-                    latestPrInfo = await githubClient.GetPrInfoAsync(latestPr.Value, Config.Cts.Token).ConfigureAwait(false);
+                    latestPrInfo = await githubClient.GetPrInfoAsync(latestPr.Value).ConfigureAwait(false);
                     url = latestPrInfo?.HtmlUrl ?? "https://github.com/RPCS3/rpcs3/pull/" + latestPr;
                     prDesc = $"PR #{latestPr} by {latestPrInfo?.User?.Login ?? "???"}";
                 }
@@ -41,7 +41,7 @@ namespace CompatBot.Utils.ResultFormatters
                     prDesc = "PR #???";
 
                 if (currentPr > 0 && currentPr != latestPr)
-                    currentPrInfo = await githubClient.GetPrInfoAsync(currentPr.Value, Config.Cts.Token).ConfigureAwait(false);
+                    currentPrInfo = await githubClient.GetPrInfoAsync(currentPr.Value).ConfigureAwait(false);
             }
             var desc = latestPrInfo?.Title;
             if (!string.IsNullOrEmpty(desc)


### PR DESCRIPTION
The open issue for #420 is to migrate to the GraphQL API, but the official .NET client is in beta. With that in mind, I figured I'd have a go at implementing their official client for the REST API.

If you don't want to go ahead with this, I'll understand! It'd be interesting to try out the GraphQL client too, even with their warnings. Not sure what parts are missing from it.

There's a few issues to address with this solution:

- I'm not sure what call with their client is equivalent to the call being made in `GetStatusesAsync()`. I came across docs for [Statuses](https://developer.github.com/v3/repos/statuses/#list-statuses-for-a-specific-ref) but I'm not sure if the answer is in there.
- There's a `github.Miscellaneous.GetRateLimits()` API call that's available, instead of parsing results out of the headers, which is cleaner but involves making an extra call (not sure if it actually _counts_ toward the rate limits...)
- I wasn't sure whether to replace your POCO's or not, so I added implicit converters to the classes, to save GitHub's types as the ones already built-in to the app.