### PR TITLE
Implementing GraphQL API for accessing GitHub data

### DIFF
--- a/Clients/GithubClient/GithubClient.csproj
+++ b/Clients/GithubClient/GithubClient.csproj
@@ -7,6 +7,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.0.0" />
+    <PackageReference Include="Octokit.GraphQL" Version="0.1.4-beta" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Clients/GithubClient/POCOs/PrInfo.cs
+++ b/Clients/GithubClient/POCOs/PrInfo.cs
@@ -2,50 +2,50 @@
 
 namespace GithubClient.POCOs
 {
-    public class PrInfo
-    {
-        public string HtmlUrl;
-        public int Number;
-        public string State;
-        public string Title;
-        public GithubUser User;
-        public DateTime CreatedAt;
-        public DateTime? UpdatedAt;
-        public DateTime? ClosedAt;
-        public DateTime? MergedAt;
-        public string MergeCommitSha;
-        public string StatusesUrl;
-        public int Additions;
-        public int Deletions;
-        public int ChangedFiles;
-        public string Message;
-    }
+    //public class PrInfo
+    //{
+    //    public string HtmlUrl;
+    //    public int Number;
+    //    public string State;
+    //    public string Title;
+    //    public GithubUser User;
+    //    public DateTime CreatedAt;
+    //    public DateTime? UpdatedAt;
+    //    public DateTime? ClosedAt;
+    //    public DateTime? MergedAt;
+    //    public string MergeCommitSha;
+    //    public string StatusesUrl;
+    //    public int Additions;
+    //    public int Deletions;
+    //    public int ChangedFiles;
+    //    public string Message;
+    //}
 
-    public class IssueInfo
-    {
-        public string HtmlUrl;
-        public int Number;
-        public string State;
-        public string Title;
-        public GithubUser User;
-        public DateTime CreatedAt;
-        public DateTime? UpdatedAt;
-        public DateTime? ClosedAt;
-        public DateTime? MergedAt;
-        public string Body;
-        public PullRequestReference PullRequest;
-    }
+    //public class IssueInfo
+    //{
+    //    public string HtmlUrl;
+    //    public int Number;
+    //    public string State;
+    //    public string Title;
+    //    public GithubUser User;
+    //    public DateTime CreatedAt;
+    //    public DateTime? UpdatedAt;
+    //    public DateTime? ClosedAt;
+    //    public DateTime? MergedAt;
+    //    public string Body;
+    //    public PullRequestReference PullRequest;
+    //}
 
-    public class GithubUser
-    {
-        public string Login;
-    }
+    //public class GithubUser
+    //{
+    //    public string Login;
+    //}
 
-    public class PullRequestReference
-    {
-        public string Url;
-        public string HtmlUrl;
-        public string DiffUrl;
-        public string PatchUrl;
-    }
+    //public class PullRequestReference
+    //{
+    //    public string Url;
+    //    public string HtmlUrl;
+    //    public string DiffUrl;
+    //    public string PatchUrl;
+    //}
 }

--- a/Clients/GithubClient/POCOs/StatusInfo.cs
+++ b/Clients/GithubClient/POCOs/StatusInfo.cs
@@ -2,13 +2,13 @@
 
 namespace GithubClient.POCOs
 {
-    public class StatusInfo
-    {
-        public string State; // success
-        public string Description;
-        public string TargetUrl;
-        public string Context; // continuous-integration/appveyor/pr
-        public DateTime? CreatedAt;
-        public DateTime? UpdatedAt;
-    }
+    //public class StatusInfo
+    //{
+    //    public string State; // success
+    //    public string Description;
+    //    public string TargetUrl;
+    //    public string Context; // continuous-integration/appveyor/pr
+    //    public DateTime? CreatedAt;
+    //    public DateTime? UpdatedAt;
+    //}
 }

--- a/CompatBot/Utils/ResultFormatters/PrInfoFormatter.cs
+++ b/CompatBot/Utils/ResultFormatters/PrInfoFormatter.cs
@@ -1,51 +1,51 @@
 ﻿using DSharpPlus.Entities;
-using GithubClient.POCOs;
+using Octokit.GraphQL.Model;
 
 namespace CompatBot.Utils.ResultFormatters
 {
     internal static class PrInfoFormatter
     {
-        public static DiscordEmbedBuilder AsEmbed(this PrInfo prInfo)
+        public static DiscordEmbedBuilder AsEmbed(this PullRequest prInfo)
         {
-            var state = prInfo.GetState();
-            var stateLabel = state.state == null ? null : $"[{state.state}] ";
-            var title = $"{stateLabel}PR #{prInfo.Number} by {prInfo.User?.Login ?? "???"}";
-            return new DiscordEmbedBuilder {Title = title, Url = prInfo.HtmlUrl, Description = prInfo.Title, Color = state.color};
+            var state = prInfo.GetDiscordColor();
+            var stateLabel = $"[{prInfo.State}] ";
+            var title = $"{stateLabel}PR #{prInfo.Number} by {prInfo.Author?.Login ?? "???"}";
+            return new DiscordEmbedBuilder {Title = title, Url = prInfo.Url, Description = prInfo.Title, Color = state};
         }
 
-        public static DiscordEmbedBuilder AsEmbed(this IssueInfo issueInfo)
+        public static DiscordEmbedBuilder AsEmbed(this Issue issueInfo)
         {
-            var state = issueInfo.GetState();
-            var stateLabel = state.state == null ? null : $"[{state.state}] ";
-            var title = $"{stateLabel}Issue #{issueInfo.Number} from {issueInfo.User?.Login ?? "???"}";
-            return new DiscordEmbedBuilder {Title = title, Url = issueInfo.HtmlUrl, Description = issueInfo.Title, Color = state.color};
+            var state = issueInfo.GetDiscordColor();
+            var stateLabel = $"[{state}] ";
+            var title = $"{stateLabel}Issue #{issueInfo.Number} from {issueInfo.Author?.Login ?? "???"}";
+            return new DiscordEmbedBuilder {Title = title, Url = issueInfo.Url, Description = issueInfo.Title, Color = state};
         }
 
-        public static (string state, DiscordColor color) GetState(this PrInfo prInfo)
+        public static DiscordColor GetDiscordColor(this PullRequest prInfo)
         {
-            if (prInfo.State == "open")
-                return ("Open", Config.Colors.PrOpen);
+            if (prInfo.State == PullRequestState.Open)
+                return Config.Colors.PrOpen;
 
-            if (prInfo.State == "closed")
+            if (prInfo.State == PullRequestState.Closed)
             {
                 if (prInfo.MergedAt.HasValue)
-                    return ("Merged", Config.Colors.PrMerged);
+                    return Config.Colors.PrMerged;
 
-                return ("Closed", Config.Colors.PrClosed);
+                return Config.Colors.PrClosed;
             }
 
-            return (null, Config.Colors.DownloadLinks);
+            return Config.Colors.DownloadLinks;
         }
 
-        public static (string state, DiscordColor color) GetState(this IssueInfo issueInfo)
+        public static DiscordColor GetDiscordColor(this Issue issueInfo)
         {
-            if (issueInfo.State == "open")
-                return ("Open", Config.Colors.PrOpen);
+            if (issueInfo.State == IssueState.Open)
+                return Config.Colors.PrOpen;
 
-            if (issueInfo.State == "closed")
-                return ("Closed", Config.Colors.PrClosed);
+            if (issueInfo.State == IssueState.Closed)
+                return Config.Colors.PrClosed;
 
-            return (null, Config.Colors.DownloadLinks);
+            return Config.Colors.DownloadLinks;
         }
     }
 }


### PR DESCRIPTION
I wanted to get this "out there" so others could look at it. It's not a complete solution yet, but at least it's a start for addressing https://github.com/RPCS3/discord-bot/issues/420:

- I haven't fully refactored `GetStatusesAsync` in Client.cs or `LinkPrBuild` in Pr.cs yet. I'm not quite sure where to get the necessary info from or whether there's a official GitHub object to match the `StatusInfo` class.
- I _think_ the GraphQL API requires an OAUTH token now, whereas the queries were anonymous before. If that's true, then it'll be possible to make a greater amount of queries, but I'm not sure what the best way is to get an OAUTH token into the program.
- For now, I've simply commented out the built-in POCOs like `PrInfo`, `IssueInfo`, etc.
- This won't compile as-is, so the build and tests will fail. It's really just to get feedback about what's been done so far.