### PR TITLE
Workaround timezone information issues in dotnet core 3.0

### DIFF
--- a/CompatBot/Commands/ContentFilters.cs
+++ b/CompatBot/Commands/ContentFilters.cs
@@ -386,7 +386,7 @@ namespace CompatBot.Commands
                 );
             msg = await msg.UpdateOrCreateMessageAsync(ctx.Channel, "Please specify filter **action(s)**", embed: embed).ConfigureAwait(false);
             errorMsg = null;
-            (msg, txt, emoji) = await interact.WaitForMessageOrReactionAsync(msg, ctx.User, InteractTimeout, abort, previousPage, nextPage, letterR, letterW, letterM, letterE, (filter.IsComplete() ? saveEdit : null)).ConfigureAwait(false);
+            (msg, txt, emoji) = await interact.WaitForMessageOrReactionAsync(msg, ctx.User, InteractTimeout, abort, previousPage, nextPage, letterR, letterW, letterM, letterE, letterU, (filter.IsComplete() ? saveEdit : null)).ConfigureAwait(false);
             if (emoji != null)
             {
                 if (emoji.Emoji == abort)

--- a/CompatBot/Program.cs
+++ b/CompatBot/Program.cs
@@ -268,6 +268,12 @@ namespace CompatBot
                             await channel.SendMessageAsync("Bot is up and running").ConfigureAwait(false);
                         }
                     }
+                    else
+                    {
+                        Config.Log.Debug($"Args count: {args.Length}");
+                        var pArgs = args.Select(a => a == Config.Token ? "<Token>" : $"[{a}]");
+                        Config.Log.Debug("Args: " + string.Join(" ", pArgs));
+                    }
 
                     Config.Log.Debug("Running RPCS3 update check thread");
                     backgroundTasks = Task.WhenAll(

--- a/CompatBot/Utils/TimeParser.cs
+++ b/CompatBot/Utils/TimeParser.cs
@@ -28,26 +28,26 @@ namespace CompatBot.Utils
                 select tzn,
                 StringComparer.InvariantCultureIgnoreCase
             );
-            Config.Log.Trace("[TZI] Unique TZA names: " + uniqueNames.Count);
+            Config.Log.Debug("[TZI] Unique TZA names: " + uniqueNames.Count);
             var tzList = TimeZoneInfo.GetSystemTimeZones();
-            Config.Log.Trace("[TZI] System TZI count: " + tzList.Count);
+            Config.Log.Debug("[TZI] System TZI count: " + tzList.Count);
             var result = new Dictionary<string, TimeZoneInfo>();
             foreach (var tzi in tzList)
             {
-                Config.Log.Trace($"[TZI] Checking {tzi.Id} ({tzi.StandardName} / {tzi.DaylightName})");
+                Config.Log.Debug($"[TZI] Checking {tzi.Id} ({tzi.StandardName} / {tzi.DaylightName})");
                 if (uniqueNames.Contains(tzi.StandardName) || uniqueNames.Contains(tzi.DaylightName))
                 {
-                    Config.Log.Trace("[TZI] Looks like it's a match!");
+                    Config.Log.Debug("[TZI] Looks like it's a match!");
                     var acronyms = from tza in TimeZoneAcronyms
                         where tza.Value.Any(name => name.Equals(tzi.StandardName, StringComparison.InvariantCultureIgnoreCase))
                               || tza.Value.Any(name => name.Equals(tzi.DaylightName, StringComparison.InvariantCulture))
                         select tza.Key;
-                    Config.Log.Trace("[TZI] Matched acronyms: " + string.Join(", ", acronyms));
+                    Config.Log.Debug("[TZI] Matched acronyms: " + string.Join(", ", acronyms));
                     foreach (var tza in acronyms)
                         result[tza] = tzi;
                 }
             }
-            Config.Log.Trace("[TZI] Total matched acronyms: " + result.Count);
+            Config.Log.Debug("[TZI] Total matched acronyms: " + result.Count);
             TimeZoneMap = result;
         }
 

--- a/CompatBot/Utils/TimeParser.cs
+++ b/CompatBot/Utils/TimeParser.cs
@@ -34,7 +34,8 @@ namespace CompatBot.Utils
                 if (uniqueNames.Contains(tzi.StandardName) || uniqueNames.Contains(tzi.StandardName))
                 {
                     var acronyms = from tza in TimeZoneAcronyms
-                        where tza.Value.Contains(tzi.StandardName) || tza.Value.Contains(tzi.DaylightName)
+                        where tza.Value.Any(name => name.Equals(tzi.StandardName, StringComparison.InvariantCultureIgnoreCase))
+                              || tza.Value.Any(name => name.Equals(tzi.DaylightName, StringComparison.InvariantCulture))
                         select tza.Key;
                     foreach (var tza in acronyms)
                         result[tza] = tzi;

--- a/CompatBot/Utils/TimeParser.cs
+++ b/CompatBot/Utils/TimeParser.cs
@@ -10,14 +10,14 @@ namespace CompatBot.Utils
         
         public static readonly Dictionary<string, string[]> TimeZoneAcronyms = new Dictionary<string, string[]>
         {
-            ["PT"] = new[] { "Pacific Standard Time" },
-            ["PST"] = new[] { "Pacific Standard Time" },
-            ["PDT"] = new[] { "Pacific Standard Time" },
-            ["EST"] = new[] { "Eastern Standard Time" },
-            ["EDT"] = new[] { "Eastern Standard Time" },
-            ["CEST"] = new[] { "Central European Standard Time" },
-            ["BST"] = new[] { "British Summer Time", "GMT Standard Time" },
-            ["JST"] = new[] { "Japan Standard Time", "Tokyo Standard Time" },
+            ["PT"] = new[] { "Pacific Standard Time", "America/Los_Angeles" },
+            ["PST"] = new[] { "Pacific Standard Time", "America/Los_Angeles" },
+            ["PDT"] = new[] { "Pacific Standard Time", "Pacific Daylight Time", "America/Los_Angeles" },
+            ["EST"] = new[] { "Eastern Standard Time", "America/New_York" },
+            ["EDT"] = new[] { "Eastern Standard Time", "Eastern Daylight Time", "America/New_York" },
+            ["CEST"] = new[] { "Central European Standard Time", "Europe/Berlin" },
+            ["BST"] = new[] { "British Summer Time", "GMT Standard Time", "Europe/London" },
+            ["JST"] = new[] { "Japan Standard Time", "Tokyo Standard Time", "Asia/Tokyo" },
         };
 
         static TimeParser()
@@ -28,25 +28,25 @@ namespace CompatBot.Utils
                 select tzn,
                 StringComparer.InvariantCultureIgnoreCase
             );
-            Config.Log.Debug("[TZI] Unique TZA names: " + uniqueNames.Count);
+            Config.Log.Trace("[TZI] Unique TZA names: " + uniqueNames.Count);
             var tzList = TimeZoneInfo.GetSystemTimeZones();
-            Config.Log.Debug("[TZI] System TZI count: " + tzList.Count);
+            Config.Log.Trace("[TZI] System TZI count: " + tzList.Count);
             var result = new Dictionary<string, TimeZoneInfo>();
             foreach (var tzi in tzList)
             {
-                Config.Log.Debug($"[TZI] Checking {tzi.Id} ({tzi.DisplayName} / {tzi.StandardName} / {tzi.DaylightName})");
-                if (uniqueNames.Contains(tzi.StandardName) || uniqueNames.Contains(tzi.DaylightName) || uniqueNames.Contains(tzi.DisplayName))
+                Config.Log.Trace($"[TZI] Checking {tzi.Id} ({tzi.DisplayName} / {tzi.StandardName} / {tzi.DaylightName})");
+                if (uniqueNames.Contains(tzi.StandardName) || uniqueNames.Contains(tzi.DaylightName) || uniqueNames.Contains(tzi.Id))
                 {
-                    Config.Log.Debug("[TZI] Looks like it's a match!");
+                    Config.Log.Trace("[TZI] Looks like it's a match!");
                     var acronyms = from tza in TimeZoneAcronyms
-                        where tza.Value.Contains(tzi.StandardName) || tza.Value.Contains(tzi.DaylightName) || tza.Value.Contains(tzi.DisplayName)
+                        where tza.Value.Contains(tzi.StandardName) || tza.Value.Contains(tzi.DaylightName) || tza.Value.Contains(tzi.Id)
                         select tza.Key;
-                    Config.Log.Debug("[TZI] Matched acronyms: " + string.Join(", ", acronyms));
+                    Config.Log.Trace("[TZI] Matched acronyms: " + string.Join(", ", acronyms));
                     foreach (var tza in acronyms)
                         result[tza] = tzi;
                 }
             }
-            Config.Log.Debug("[TZI] Total matched acronyms: " + result.Count);
+            Config.Log.Trace("[TZI] Total matched acronyms: " + result.Count);
             TimeZoneMap = result;
         }
 

--- a/CompatBot/Utils/TimeParser.cs
+++ b/CompatBot/Utils/TimeParser.cs
@@ -34,13 +34,12 @@ namespace CompatBot.Utils
             var result = new Dictionary<string, TimeZoneInfo>();
             foreach (var tzi in tzList)
             {
-                Config.Log.Debug($"[TZI] Checking {tzi.Id} ({tzi.StandardName} / {tzi.DaylightName})");
-                if (uniqueNames.Contains(tzi.StandardName) || uniqueNames.Contains(tzi.DaylightName))
+                Config.Log.Debug($"[TZI] Checking {tzi.Id} ({tzi.DisplayName} / {tzi.StandardName} / {tzi.DaylightName})");
+                if (uniqueNames.Contains(tzi.StandardName) || uniqueNames.Contains(tzi.DaylightName) || uniqueNames.Contains(tzi.DisplayName))
                 {
                     Config.Log.Debug("[TZI] Looks like it's a match!");
                     var acronyms = from tza in TimeZoneAcronyms
-                        where tza.Value.Any(name => name.Equals(tzi.StandardName, StringComparison.InvariantCultureIgnoreCase))
-                              || tza.Value.Any(name => name.Equals(tzi.DaylightName, StringComparison.InvariantCulture))
+                        where tza.Value.Contains(tzi.StandardName) || tza.Value.Contains(tzi.DaylightName) || tza.Value.Contains(tzi.DisplayName)
                         select tza.Key;
                     Config.Log.Debug("[TZI] Matched acronyms: " + string.Join(", ", acronyms));
                     foreach (var tza in acronyms)

--- a/CompatBot/Utils/TimeParser.cs
+++ b/CompatBot/Utils/TimeParser.cs
@@ -25,22 +25,29 @@ namespace CompatBot.Utils
             var uniqueNames = new HashSet<string>(
                 from tznl in TimeZoneAcronyms.Values
                 from tzn in tznl
-                select tzn
+                select tzn,
+                StringComparer.InvariantCultureIgnoreCase
             );
+            Config.Log.Trace("[TZI] Unique TZA names: " + uniqueNames.Count);
             var tzList = TimeZoneInfo.GetSystemTimeZones();
+            Config.Log.Trace("[TZI] System TZI count: " + tzList.Count);
             var result = new Dictionary<string, TimeZoneInfo>();
             foreach (var tzi in tzList)
             {
-                if (uniqueNames.Contains(tzi.StandardName) || uniqueNames.Contains(tzi.StandardName))
+                Config.Log.Trace($"[TZI] Checking {tzi.Id} ({tzi.StandardName} / {tzi.DaylightName})");
+                if (uniqueNames.Contains(tzi.StandardName) || uniqueNames.Contains(tzi.DaylightName))
                 {
+                    Config.Log.Trace("[TZI] Looks like it's a match!");
                     var acronyms = from tza in TimeZoneAcronyms
                         where tza.Value.Any(name => name.Equals(tzi.StandardName, StringComparison.InvariantCultureIgnoreCase))
                               || tza.Value.Any(name => name.Equals(tzi.DaylightName, StringComparison.InvariantCulture))
                         select tza.Key;
+                    Config.Log.Trace("[TZI] Matched acronyms: " + string.Join(", ", acronyms));
                     foreach (var tza in acronyms)
                         result[tza] = tzi;
                 }
             }
+            Config.Log.Trace("[TZI] Total matched acronyms: " + result.Count);
             TimeZoneMap = result;
         }
 


### PR DESCRIPTION
Apparently `TimeZoneInfo` no longer provides human readable names, at all