### PR TITLE
Channel history lookup overhaul

### DIFF
--- a/Clients/CompatApiClient/CompatApiClient.csproj
+++ b/Clients/CompatApiClient/CompatApiClient.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="3.1.8" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="1.3.5" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NLog" Version="4.7.4" />
+    <PackageReference Include="NLog" Version="4.7.5" />
   </ItemGroup>
 
 </Project>

--- a/CompatBot/Commands/Attributes/LimitedToOfftopicChannel.cs
+++ b/CompatBot/Commands/Attributes/LimitedToOfftopicChannel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using CompatBot.EventHandlers;
 using CompatBot.Utils;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
@@ -18,7 +19,7 @@ namespace CompatBot.Commands.Attributes
 
 			try
 			{
-				var msgList = await ctx.Channel.GetMessagesAsync(10).ConfigureAwait(false);
+				var msgList = await ctx.Channel.GetMessagesCachedAsync(10).ConfigureAwait(false);
 				if (msgList.Any(m => m.Author.IsCurrent
 									&& m.Content is string s
 									&& s.Contains(ctx.Command.QualifiedName, StringComparison.InvariantCultureIgnoreCase)))

--- a/CompatBot/Commands/Attributes/LimitedToSpamChannel.cs
+++ b/CompatBot/Commands/Attributes/LimitedToSpamChannel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Linq;
 using System.Threading.Tasks;
+using CompatBot.EventHandlers;
 using CompatBot.Utils;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.CommandsNext.Attributes;
@@ -18,7 +19,7 @@ namespace CompatBot.Commands.Attributes
 
             try
             {
-                var msgList = await ctx.Channel.GetMessagesAsync(10).ConfigureAwait(false);
+                var msgList = await ctx.Channel.GetMessagesCachedAsync(10).ConfigureAwait(false);
                 if (msgList.Any(m => m.Author.IsCurrent
                                      && m.Content is string s
                                      && s.Contains(ctx.Command.QualifiedName, StringComparison.InvariantCultureIgnoreCase)))

--- a/CompatBot/Commands/Explain.cs
+++ b/CompatBot/Commands/Explain.cs
@@ -34,7 +34,7 @@ namespace CompatBot.Commands
             var sourceTerm = term;
             if (string.IsNullOrEmpty(term))
             {
-                var lastBotMessages = await ctx.Channel.GetMessagesBeforeAsync(ctx.Message.Id, 10).ConfigureAwait(false);
+                var lastBotMessages = await ctx.Channel.GetMessagesBeforeCachedAsync(ctx.Message.Id, 10).ConfigureAwait(false);
                 var showList = true;
                 foreach (var pastMsg in lastBotMessages)
                     if (pastMsg.Embeds.FirstOrDefault() is DiscordEmbed pastEmbed

--- a/CompatBot/Commands/Pr.cs
+++ b/CompatBot/Commands/Pr.cs
@@ -21,7 +21,7 @@ namespace CompatBot.Commands
     {
         private static readonly GithubClient.Client githubClient = new GithubClient.Client();
         private static readonly CompatApiClient.Client compatApiClient = new CompatApiClient.Client();
-        private static readonly TimeSpan AvgBuildTime = TimeSpan.FromMinutes(30);
+        internal static readonly TimeSpan AvgBuildTime = TimeSpan.FromMinutes(30);
 
         [GroupCommand]
         public Task List(CommandContext ctx, [Description("Get information for specific PR number")] int pr) => LinkPrBuild(ctx.Client, ctx.Message, pr);

--- a/CompatBot/Commands/Vision.cs
+++ b/CompatBot/Commands/Vision.cs
@@ -7,6 +7,7 @@ using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
 using ColorThiefDotNet;
+using CompatBot.EventHandlers;
 using CompatBot.Utils;
 using CompatBot.Utils.Extensions;
 using DSharpPlus;
@@ -387,7 +388,7 @@ namespace CompatBot.Commands
                     && ctx.Channel.PermissionsFor(ctx.Client.GetMember(ctx.Guild, ctx.Client.CurrentUser)).HasPermission(Permissions.ReadMessageHistory))
                     try
                     {
-                        var previousMessages = await ctx.Channel.GetMessagesBeforeAsync(ctx.Message.Id, 10).ConfigureAwait(false);
+                        var previousMessages = await ctx.Channel.GetMessagesBeforeCachedAsync(ctx.Message.Id, 10).ConfigureAwait(false);
                         var (selectedMsg, selectedAttachment) = (
                             from m in previousMessages
                             where m.Attachments?.Count > 0

--- a/CompatBot/CompatBot.csproj
+++ b/CompatBot/CompatBot.csproj
@@ -30,16 +30,16 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DSharpPlus" Version="4.0.0-nightly-00722" />
-    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.0.0-nightly-00722" />
-    <PackageReference Include="DSharpPlus.Interactivity" Version="4.0.0-nightly-00722" />
-    <PackageReference Include="Google.Apis.Drive.v3" Version="1.49.0.2060" />
+    <PackageReference Include="DSharpPlus" Version="4.0.0-nightly-00728" />
+    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.0.0-nightly-00728" />
+    <PackageReference Include="DSharpPlus.Interactivity" Version="4.0.0-nightly-00728" />
+    <PackageReference Include="Google.Apis.Drive.v3" Version="1.49.0.2072" />
     <PackageReference Include="ksemenenko.ColorThief" Version="1.1.1.4" />
     <PackageReference Include="MathParser.org-mXparser" Version="4.4.2" />
     <PackageReference Include="MegaApiClient" Version="1.8.2" />
-    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.14.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.14.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.14.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights" Version="2.15.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.15.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.15.0" />
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="5.2.7" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.ComputerVision" Version="5.0.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="3.1.8" />
@@ -56,9 +56,9 @@
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="16.153.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
     <PackageReference Include="Microsoft.VisualStudio.Services.Client" Version="16.153.0" />
-    <PackageReference Include="Nerdbank.Streams" Version="2.5.76" />
+    <PackageReference Include="Nerdbank.Streams" Version="2.6.78" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
-    <PackageReference Include="NLog" Version="4.7.4" />
+    <PackageReference Include="NLog" Version="4.7.5" />
     <PackageReference Include="NLog.Extensions.Logging" Version="1.6.5" />
     <PackageReference Include="NReco.Text.AhoCorasickDoubleArrayTrie" Version="1.0.2" />
     <PackageReference Include="SharpCompress" Version="0.26.0" />

--- a/CompatBot/Config.cs
+++ b/CompatBot/Config.cs
@@ -74,6 +74,7 @@ namespace CompatBot
         public static int BuildNumberDifferenceForOutdatedBuilds => config.GetValue(nameof(BuildNumberDifferenceForOutdatedBuilds), 10);
         public static int MinimumPiracyTriggerLength => config.GetValue(nameof(MinimumPiracyTriggerLength), 4);
         public static int MaxSyscallResultLines => config.GetValue(nameof(MaxSyscallResultLines), 13);
+        public static int ChannelMessageHistorySize => config.GetValue(nameof(ChannelMessageHistorySize), 100);
         public static string Token => config.GetValue(nameof(Token), "");
         public static string AzureDevOpsToken => config.GetValue(nameof(AzureDevOpsToken), "");
         public static string AzureComputerVisionKey => config.GetValue(nameof(AzureComputerVisionKey), "");

--- a/CompatBot/EventHandlers/DiscordInviteFilter.cs
+++ b/CompatBot/EventHandlers/DiscordInviteFilter.cs
@@ -72,7 +72,7 @@ namespace CompatBot.EventHandlers
 
                     try
                     {
-                        var messages = await channel.GetMessagesAsync(100).ConfigureAwait(false);
+                        var messages = await channel.GetMessagesCachedAsync(100).ConfigureAwait(false);
                         var messagesToCheck = from msg in messages
                             where msg.CreationTimestamp > after
                             select msg;

--- a/CompatBot/EventHandlers/GithubLinksHandler.cs
+++ b/CompatBot/EventHandlers/GithubLinksHandler.cs
@@ -32,7 +32,7 @@ namespace CompatBot.EventHandlers
                 if (BotReactionsHandler.NeedToSilence(msg).needToChill)
                     return;
 
-            lastBotMessages = await args.Channel.GetMessagesBeforeAsync(args.Message.Id, Config.ProductCodeLookupHistoryThrottle).ConfigureAwait(false);
+            lastBotMessages = await args.Channel.GetMessagesBeforeCachedAsync(args.Message.Id, Config.ProductCodeLookupHistoryThrottle).ConfigureAwait(false);
             StringBuilder previousRepliesBuilder = null;
             foreach (var msg in lastBotMessages)
             {

--- a/CompatBot/EventHandlers/GlobalMessageCache.cs
+++ b/CompatBot/EventHandlers/GlobalMessageCache.cs
@@ -1,9 +1,12 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using CompatBot.Utils;
 using DSharpPlus.Entities;
 using DSharpPlus.EventArgs;
+using Microsoft.VisualStudio.Services.Common;
 
 namespace CompatBot.EventHandlers
 {
@@ -12,7 +15,7 @@ namespace CompatBot.EventHandlers
     internal static class GlobalMessageCache
     {
         private static readonly TCache MessageQueue = new TCache();
-        private static readonly Func<DiscordMessage, ulong> KeyGen = (DiscordMessage m) => m.Id;
+        private static readonly Func<DiscordMessage, ulong> KeyGen = m => m.Id;
 
         public static Task OnMessageCreated(MessageCreateEventArgs args)
         {
@@ -20,7 +23,11 @@ namespace CompatBot.EventHandlers
                 return Task.CompletedTask;
 
             if (!MessageQueue.TryGetValue(args.Channel.Id, out var queue))
-                MessageQueue[args.Channel.Id] = queue = new FixedLengthBuffer<ulong, DiscordMessage>(KeyGen);
+                lock (MessageQueue)
+                {
+                    if (!MessageQueue.TryGetValue(args.Channel.Id, out queue))
+                        MessageQueue[args.Channel.Id] = queue = new FixedLengthBuffer<ulong, DiscordMessage>(KeyGen);
+                }
             lock(queue.syncObj)
                 queue.Add(args.Message);
 
@@ -68,6 +75,71 @@ namespace CompatBot.EventHandlers
             lock(queue.syncObj)
                 queue.AddOrReplace(args.Message);
             return Task.CompletedTask;
+        }
+
+        internal static Task<List<DiscordMessage>> GetMessagesCachedAsync(this DiscordChannel ch, int count = 100)
+        {
+            if (!MessageQueue.TryGetValue(ch.Id, out var queue))
+                lock (MessageQueue)
+                    if (!MessageQueue.TryGetValue(ch.Id, out queue))
+                        MessageQueue[ch.Id] = queue = new FixedLengthBuffer<ulong, DiscordMessage>(KeyGen);
+            List<DiscordMessage> result;
+            lock(queue.syncObj)
+                result = queue.Reverse().Take(count).ToList();
+            var cacheCount = result.Count;
+            var fetchCount = Math.Max(count - cacheCount, 0);
+            if (fetchCount > 0)
+            {
+                IReadOnlyList<DiscordMessage> fetchedList;
+                if (result.Any())
+                    fetchedList = ch.GetMessagesBeforeAsync(result[0].Id, fetchCount).ConfigureAwait(false).GetAwaiter().GetResult();
+                else
+                    fetchedList = ch.GetMessagesAsync(fetchCount).ConfigureAwait(false).GetAwaiter().GetResult();
+                result.AddRange(fetchedList);
+                if (queue.Count < Config.ChannelMessageHistorySize)
+                    lock (queue.syncObj)
+                    {
+                        // items in queue might've changed since the previous check at the beginning of this method
+                        var freshCopy = queue.Reverse().ToList();
+                        queue.Clear();
+                        queue.AddRange(freshCopy.Concat(fetchedList).Distinct().Reverse());
+                    }
+            }
+            return Task.FromResult(result);
+        }
+
+        internal static Task<List<DiscordMessage>> GetMessagesBeforeCachedAsync(this DiscordChannel ch, ulong msgId, int count = 100)
+        {
+            if (!MessageQueue.TryGetValue(ch.Id, out var queue))
+                lock (MessageQueue)
+                    if (!MessageQueue.TryGetValue(ch.Id, out queue))
+                        MessageQueue[ch.Id] = queue = new FixedLengthBuffer<ulong, DiscordMessage>(KeyGen);
+            List<DiscordMessage> result;
+            lock(queue.syncObj)
+                result = queue.Reverse().SkipWhile(m => m.Id >= msgId).Take(count).ToList();
+            var cacheCount = result.Count;
+            var fetchCount = Math.Max(count - cacheCount, 0);
+            if (fetchCount > 0)
+            {
+                IReadOnlyList<DiscordMessage> fetchedList;
+                if (result.Any())
+                {
+                    fetchedList = ch.GetMessagesBeforeAsync(result[0].Id, fetchCount).ConfigureAwait(false).GetAwaiter().GetResult();
+                    if (queue.Count < Config.ChannelMessageHistorySize)
+                        lock (queue.syncObj)
+                        {
+                            // items in queue might've changed since the previous check at the beginning of this method
+                            var freshCopy = queue.Reverse().ToList();
+                            queue.Clear();
+                            queue.AddRange(freshCopy.Concat(fetchedList).Distinct().Reverse());
+                        }
+                }
+                else
+                    fetchedList = ch.GetMessagesBeforeAsync(msgId, fetchCount).ConfigureAwait(false).GetAwaiter().GetResult();
+                result.AddRange(fetchedList);
+            }
+            return Task.FromResult(result);
+
         }
     }
 }

--- a/CompatBot/EventHandlers/GlobalMessageCache.cs
+++ b/CompatBot/EventHandlers/GlobalMessageCache.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+using CompatBot.Utils;
+using DSharpPlus.Entities;
+using DSharpPlus.EventArgs;
+
+namespace CompatBot.EventHandlers
+{
+    using TCache = ConcurrentDictionary<ulong, FixedLengthBuffer<ulong, DiscordMessage>>;
+
+    internal static class GlobalMessageCache
+    {
+        private static readonly TCache MessageQueue = new TCache();
+        private static readonly Func<DiscordMessage, ulong> KeyGen = (DiscordMessage m) => m.Id;
+
+        public static Task OnMessageCreated(MessageCreateEventArgs args)
+        {
+            if (args.Channel.IsPrivate)
+                return Task.CompletedTask;
+
+            if (!MessageQueue.TryGetValue(args.Channel.Id, out var queue))
+                MessageQueue[args.Channel.Id] = queue = new FixedLengthBuffer<ulong, DiscordMessage>(KeyGen);
+            lock(queue.syncObj)
+                queue.Add(args.Message);
+
+            while (queue.Count > Config.ChannelMessageHistorySize)
+                lock(queue.syncObj)
+                    queue.TrimExcess();
+            return Task.CompletedTask;
+        }
+
+        public static Task OnMessageDeleted(MessageDeleteEventArgs args)
+        {
+            if (args.Channel.IsPrivate)
+                return Task.CompletedTask;
+            
+            if (!MessageQueue.TryGetValue(args.Channel.Id, out var queue))
+                return Task.CompletedTask;
+
+            lock (queue.syncObj)
+                queue.Evict(args.Message.Id);
+            return Task.CompletedTask;
+        }
+
+        public static Task OnMessagesBulkDeleted(MessageBulkDeleteEventArgs args)
+        {
+            if (args.Channel.IsPrivate)
+                return Task.CompletedTask;
+            
+            if (!MessageQueue.TryGetValue(args.Channel.Id, out var queue))
+                return Task.CompletedTask;
+
+            lock (queue.syncObj)
+                foreach (var m in args.Messages)
+                    queue.Evict(m.Id);
+            return Task.CompletedTask;
+        }
+
+        public static Task OnMessageUpdated(MessageUpdateEventArgs args)
+        {
+            if (args.Channel.IsPrivate)
+                return Task.CompletedTask;
+            
+            if (!MessageQueue.TryGetValue(args.Channel.Id, out var queue))
+                return Task.CompletedTask;
+            
+            lock(queue.syncObj)
+                queue.AddOrReplace(args.Message);
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/CompatBot/EventHandlers/PostLogHelpHandler.cs
+++ b/CompatBot/EventHandlers/PostLogHelpHandler.cs
@@ -46,7 +46,7 @@ namespace CompatBot.EventHandlers
             try
             {
                 var explanation = await GetExplanationAsync(string.IsNullOrEmpty(match.Groups["vulkan"].Value) ? "log" : "vulkan-1").ConfigureAwait(false);
-                var lastBotMessages = await args.Channel.GetMessagesBeforeAsync(args.Message.Id, 10).ConfigureAwait(false);
+                var lastBotMessages = await args.Channel.GetMessagesBeforeCachedAsync(args.Message.Id, 10).ConfigureAwait(false);
                 foreach (var msg in lastBotMessages)
                     if (BotReactionsHandler.NeedToSilence(msg).needToChill
                         || (msg.Author.IsCurrent && msg.Content == explanation.Text))

--- a/CompatBot/EventHandlers/ProductCodeLookup.cs
+++ b/CompatBot/EventHandlers/ProductCodeLookup.cs
@@ -31,7 +31,7 @@ namespace CompatBot.EventHandlers
                 if (BotReactionsHandler.NeedToSilence(msg).needToChill)
                     return;
 
-            lastBotMessages = await args.Channel.GetMessagesBeforeAsync(args.Message.Id, Config.ProductCodeLookupHistoryThrottle).ConfigureAwait(false);
+            lastBotMessages = await args.Channel.GetMessagesBeforeCachedAsync(args.Message.Id, Config.ProductCodeLookupHistoryThrottle).ConfigureAwait(false);
             StringBuilder previousRepliesBuilder = null;
             foreach (var msg in lastBotMessages)
             {

--- a/CompatBot/EventHandlers/Starbucks.cs
+++ b/CompatBot/EventHandlers/Starbucks.cs
@@ -208,26 +208,32 @@ namespace CompatBot.EventHandlers
         }
 
 
-        private static Task CheckGameFansAsync(DiscordClient client, DiscordChannel channel, DiscordMessage message)
+        private static async Task CheckGameFansAsync(DiscordClient client, DiscordChannel channel, DiscordMessage message)
         {
             var bot = client.GetMember(channel.Guild, client.CurrentUser);
             var ch = channel.IsPrivate ? channel.Users.FirstOrDefault(u => u.Id != client.CurrentUser.Id)?.Username + "'s DM" : "#" + channel.Name;
             if (!channel.PermissionsFor(bot).HasPermission(Permissions.AddReactions))
             {
                 Config.Log.Debug($"No permissions to react in {ch}");
-                return Task.CompletedTask;
+                return;
             }
 
             var mood = client.GetEmoji(":sqvat:", "😒");
             if (message.Reactions.Any(r => r.Emoji == mood && r.IsMe))
-                return Task.CompletedTask;
+                return;
 
             var reactionMsg = string.Concat(message.Reactions.Select(r => TextMap.TryGetValue(r.Emoji, out var txt) ? txt : " ")).Trim();
             if (string.IsNullOrEmpty(reactionMsg))
-                return Task.CompletedTask;
+                return;
 
             Config.Log.Debug($"Emoji text: {reactionMsg} (in {ch})");
-            return Task.CompletedTask;
+
+            if (reactionMsg.Contains("UFC"))
+            {
+                await message.CreateReactionAsync(mood).ConfigureAwait(false);
+                await message.CreateReactionAsync(DiscordEmoji.FromUnicode("🇳")).ConfigureAwait(false);
+                await message.CreateReactionAsync(DiscordEmoji.FromUnicode("🇴")).ConfigureAwait(false);
+            }
         }
     }
 }

--- a/CompatBot/EventHandlers/Starbucks.cs
+++ b/CompatBot/EventHandlers/Starbucks.cs
@@ -97,7 +97,7 @@ namespace CompatBot.EventHandlers
                 var checkTasks = new List<Task>();
                 foreach (var channel in guild.Channels.Values.Where(ch => Config.Moderation.Channels.Contains(ch.Id)))
                 {
-                    var messages = await channel.GetMessagesAsync().ConfigureAwait(false);
+                    var messages = await channel.GetMessagesCachedAsync().ConfigureAwait(false);
                     var messagesToCheck = from msg in messages
                         where msg.CreationTimestamp > after && msg.Reactions.Any(r => r.Emoji == Config.Reactions.Starbucks && r.Count >= Config.Moderation.StarbucksThreshold)
                         select msg;

--- a/CompatBot/Program.cs
+++ b/CompatBot/Program.cs
@@ -231,6 +231,7 @@ namespace CompatBot
 
                 client.MessageCreated += _ => { Watchdog.TimeSinceLastIncomingMessage.Restart(); return Task.CompletedTask;};
                 client.MessageCreated += ContentFilterMonitor.OnMessageCreated; // should be first
+                client.MessageCreated += GlobalMessageCache.OnMessageCreated;
                 if (!string.IsNullOrEmpty(Config.AzureComputerVisionKey))
                     client.MessageCreated += MediaScreenshotMonitor.OnMessageCreated;
                 client.MessageCreated += ProductCodeLookup.OnMessageCreated;
@@ -245,15 +246,19 @@ namespace CompatBot
                 client.MessageCreated += IsTheGamePlayableHandler.OnMessageCreated;
                 client.MessageCreated += EmpathySimulationHandler.OnMessageCreated;
 
+                client.MessageUpdated += GlobalMessageCache.OnMessageUpdated;
                 client.MessageUpdated += ContentFilterMonitor.OnMessageUpdated;
                 client.MessageUpdated += DiscordInviteFilter.OnMessageUpdated;
                 client.MessageUpdated += EmpathySimulationHandler.OnMessageUpdated;
 
+                client.MessageDeleted += GlobalMessageCache.OnMessageDeleted;
                 if (Config.DeletedMessagesLogChannelId > 0)
                     client.MessageDeleted += DeletedMessagesMonitor.OnMessageDeleted;
                 client.MessageDeleted += ThumbnailCacheMonitor.OnMessageDeleted;
                 client.MessageDeleted += EmpathySimulationHandler.OnMessageDeleted;
 
+                client.MessagesBulkDeleted += GlobalMessageCache.OnMessagesBulkDeleted;
+                
                 client.UserUpdated += UsernameSpoofMonitor.OnUserUpdated;
                 client.UserUpdated += UsernameZalgoMonitor.OnUserUpdated;
 

--- a/CompatBot/Utils/BufferCopyStream.cs
+++ b/CompatBot/Utils/BufferCopyStream.cs
@@ -4,7 +4,7 @@ using System.IO;
 
 namespace CompatBot.Utils
 {
-    internal class BufferCopyStream : Stream, IDisposable
+	internal class BufferCopyStream : Stream, IDisposable
     {
         private readonly Stream baseStream;
         private bool usedForReads;

--- a/CompatBot/Utils/Extensions/DiscordClientExtensions.cs
+++ b/CompatBot/Utils/Extensions/DiscordClientExtensions.cs
@@ -4,6 +4,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using CompatApiClient.Utils;
+using CompatBot.EventHandlers;
 using DSharpPlus;
 using DSharpPlus.CommandsNext;
 using DSharpPlus.Entities;
@@ -106,7 +107,7 @@ namespace CompatBot.Utils
                 throw new ArgumentException(nameof(timeLimit));
 
             var afterTime = timeLimit ?? DateTime.UtcNow.AddSeconds(-30);
-            var messages = await channel.GetMessagesBeforeAsync(beforeMessageId, limit).ConfigureAwait(false);
+            var messages = await channel.GetMessagesBeforeCachedAsync(beforeMessageId, limit).ConfigureAwait(false);
             return messages.TakeWhile(m => m.CreationTimestamp > afterTime).ToList().AsReadOnly();
         }
 

--- a/CompatBot/Utils/FixedLengthBuffer.cs
+++ b/CompatBot/Utils/FixedLengthBuffer.cs
@@ -87,10 +87,19 @@ namespace CompatBot.Utils
             return true;
         }
 
+        public void CopyTo(TValue[] array, int arrayIndex)
+        {
+            var available = array.Length-arrayIndex;
+            if (available < Count)
+                throw new ArgumentException($"Insufficient lenght of the destination array: available={available}, required={Count}");
+
+            for (var i = 0; i < Count; i++)
+                array[arrayIndex + i] = lookup[keyList[i]];
+        }
+
         public bool Contains(TKey key) => lookup.ContainsKey(key);
         public bool Contains(TValue item) => Contains(makeKey(item));
-
-        public void CopyTo(TValue[] array, int arrayIndex) => throw new NotSupportedException();
+        
         public int IndexOf(TValue item) => throw new NotSupportedException();
         public void Insert(int index, TValue item) => throw new NotSupportedException();
         public void RemoveAt(int index) => throw new NotSupportedException();

--- a/CompatBot/Utils/FixedLengthBuffer.cs
+++ b/CompatBot/Utils/FixedLengthBuffer.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace CompatBot.Utils
+{
+    internal class FixedLengthBuffer<TKey, TValue>: IList<TValue>
+    {
+        internal readonly object syncObj = new object();
+        
+        public FixedLengthBuffer(Func<TValue, TKey> keyGenerator)
+        {
+            makeKey = keyGenerator ?? throw new ArgumentNullException(nameof(keyGenerator));
+        }
+
+        public FixedLengthBuffer<TKey, TValue> CloneShallow()
+        {
+            var result = new FixedLengthBuffer<TKey, TValue>(makeKey);
+            foreach (var key in keyList)
+                result.keyList.Add(key);
+            foreach (var kvp in lookup)
+                result.lookup[kvp.Key] = kvp.Value;
+            return result;
+        }
+
+        public IEnumerator<TValue> GetEnumerator() => keyList.Select(k => lookup[k]).GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+        public void Add(TValue item)
+        {
+            TKey key = makeKey(item);
+            if (!lookup.ContainsKey(key))
+                keyList.Add(key);
+            lookup[key] = item;
+        }
+
+        public void AddOrReplace(TValue item) => Add(item);
+
+        public void Clear()
+        {
+            keyList.Clear();
+            lookup.Clear();
+        }
+
+        public void TrimOldItems(int count)
+        {
+            var keys = keyList.Take(count).ToList();
+            keyList.RemoveRange(0, keys.Count);
+            foreach (var k in keys)
+                lookup.Remove(k);
+        }
+
+        public void TrimExcess()
+        {
+            if (Count <= MaxLength)
+                return;
+
+            TrimOldItems(Count - MaxLength);
+        }
+
+        public List<TValue> GetOldItems(int count)
+        {
+            return keyList.Take(Math.Min(Count, count)).Select(k => lookup[k]).ToList();
+        }
+
+        public List<TValue> GetExcess()
+        {
+            if (Count <= MaxLength)
+                return new List<TValue>(0);
+            return GetOldItems(Count - MaxLength);
+        }
+
+        public TValue Evict(TKey key)
+        {
+            var result = lookup[key];
+            lookup.Remove(key);
+            keyList.Remove(key);
+            return result;
+        }
+
+        public bool Remove(TValue item)
+        {
+            var key = makeKey(item);
+            if (!Contains(key))
+                return false;
+            
+            Evict(key);
+            return true;
+        }
+
+        public bool Contains(TKey key) => lookup.ContainsKey(key);
+        public bool Contains(TValue item) => Contains(makeKey(item));
+
+        public void CopyTo(TValue[] array, int arrayIndex) => throw new NotSupportedException();
+        public int IndexOf(TValue item) => throw new NotSupportedException();
+        public void Insert(int index, TValue item) => throw new NotSupportedException();
+        public void RemoveAt(int index) => throw new NotSupportedException();
+
+        public TValue this[int index]
+        {
+            get => throw new NotSupportedException();
+            set => throw new NotSupportedException();
+        }
+
+        public int Count => lookup.Count;
+        public bool IsReadOnly => false;
+
+        public bool NeedTrimming => Count > MaxLength + 20;
+        public TValue this[TKey index] => lookup[index];
+
+        private int MaxLength => Config.ChannelMessageHistorySize;
+        private readonly Func<TValue, TKey> makeKey;
+        private readonly List<TKey> keyList = new List<TKey>();
+        private readonly Dictionary<TKey, TValue> lookup = new Dictionary<TKey, TValue>();
+    }
+}

--- a/CompatBot/Utils/FixedLengthBuffer.cs
+++ b/CompatBot/Utils/FixedLengthBuffer.cs
@@ -60,9 +60,7 @@ namespace CompatBot.Utils
         }
 
         public List<TValue> GetOldItems(int count)
-        {
-            return keyList.Take(Math.Min(Count, count)).Select(k => lookup[k]).ToList();
-        }
+            => keyList.Take(Math.Min(Count, count)).Select(k => lookup[k]).ToList();
 
         public List<TValue> GetExcess()
         {


### PR DESCRIPTION
Trying to workaround the new Discord API call limits by keeping local cache of last N messages per channel