### PR TITLE
Update settings check

### DIFF
--- a/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.WeirdSettingsSection.cs
+++ b/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.WeirdSettingsSection.cs
@@ -29,8 +29,10 @@ namespace CompatBot.Utils.ResultFormatters
             var hasTsxFa = items["cpu_extensions"]?.Contains("TSX-FA") ?? false;
             items["has_tsx"] = hasTsx ? EnabledMark : DisabledMark;
             items["has_tsx_fa"] = hasTsxFa ? EnabledMark : DisabledMark;
-            if (items["enable_tsx"] == "Disabled" && hasTsx && !hasTsxFa)
+            if (items["enable_tsx"] == "Disabled" && hasTsx && TsxFaFixedVersion && !hasTsxFa)
                 notes.Add("ℹ TSX support is disabled");
+            else if (items["enable_tsx"] == "Enabled" && hasTsxFa)
+                notes.Add("⚠ Disable TSX support if you experience performance issues");
             if (items["spu_lower_thread_priority"] == EnabledMark
                 && threadCount > 4)
                 notes.Add("❔ `Lower SPU thread priority` is enabled on a CPU with enough threads");

--- a/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.WeirdSettingsSection.cs
+++ b/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.WeirdSettingsSection.cs
@@ -29,10 +29,20 @@ namespace CompatBot.Utils.ResultFormatters
             var hasTsxFa = items["cpu_extensions"]?.Contains("TSX-FA") ?? false;
             items["has_tsx"] = hasTsx ? EnabledMark : DisabledMark;
             items["has_tsx_fa"] = hasTsxFa ? EnabledMark : DisabledMark;
-            if (items["enable_tsx"] == "Disabled" && hasTsx && TsxFaFixedVersion && !hasTsxFa)
-                notes.Add("ℹ TSX support is disabled");
-            else if (items["enable_tsx"] == "Enabled" && hasTsxFa && !TsxFaFixedVersion)
-                notes.Add("⚠ Disable TSX support if you experience performance issues");
+            if (items["build_branch"] == "HEAD"
+                && Version.TryParse(items["build_full_version"], out var buildVersion)
+                && buildVersion < TsxFaFixedVersion)
+            {
+                if (items["enable_tsx"] == "Disabled" && hasTsx && !hasTsxFa)
+                    notes.Add("ℹ TSX support is disabled");
+                else if (items["enable_tsx"] == "Enabled" && hasTsxFa)
+                    notes.Add("⚠ Disable TSX support if you experience performance issues");
+            }
+            else
+            {
+                if (items["enable_tsx"] == "Disabled" && hasTsx)
+                    notes.Add("ℹ TSX support is disabled");
+            }
             if (items["spu_lower_thread_priority"] == EnabledMark
                 && threadCount > 4)
                 notes.Add("❔ `Lower SPU thread priority` is enabled on a CPU with enough threads");
@@ -345,7 +355,7 @@ namespace CompatBot.Utils.ResultFormatters
                 CheckSly4Settings(serial, items, notes);
                 CheckDragonsCrownSettings(serial, items, notes);
                 CheckLbpSettings(serial, items, notes, generalNotes);
-                CheckKillzone3Settings(serial, items, notes, generalNotes);
+                CheckKillzone3Settings(serial, items, notes, ppuPatches, patchNames);
             }
             else if (items["game_title"] == "vsh.self")
                 CheckVshSettings(items, notes, generalNotes);
@@ -910,12 +920,12 @@ namespace CompatBot.Utils.ResultFormatters
             "NPJA90178", "NPUA70133", "NPHA80140", "NPEA90085",
         };
 
-        private static void CheckKillzone3Settings(string serial, NameValueCollection items, List<string> notes)
+        private static void CheckKillzone3Settings(string serial, NameValueCollection items, List<string> notes, Dictionary<string, int> ppuPatches, UniqueList<string> patchNames)
         {
             if (!Killzone3Ids.Contains(serial))
                 return;
 
-            if (ppuPatches.Any() && patchNames.Count(n => n.Contains("Disable MLAA", StringComparison.OrdinalIgnoreCase)) > 1) // when MLAA patch is applied
+            if (patchNames.Any(n => n.Contains("MLAA", StringComparison.OrdinalIgnoreCase)))
             {
                 if (items["write_color_buffers"] == EnabledMark)
                     notes.Add("⚠ `Write Color Buffers` is not required with applied MLAA patch");
@@ -923,7 +933,7 @@ namespace CompatBot.Utils.ResultFormatters
             else
             {
                 if (items["write_color_buffers"] == DisabledMark)
-                    notes.Add("⚠ Please enable MLAA patch (Recommended) or `Write Color Buffers`");
+                    notes.Add("⚠ Please enable MLAA patch (recommended) or `Write Color Buffers`");
             }
         }
         private static readonly HashSet<string> RdrIds = new HashSet<string>

--- a/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.WeirdSettingsSection.cs
+++ b/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.WeirdSettingsSection.cs
@@ -343,6 +343,7 @@ namespace CompatBot.Utils.ResultFormatters
                 CheckSly4Settings(serial, items, notes);
                 CheckDragonsCrownSettings(serial, items, notes);
                 CheckLbpSettings(serial, items, notes, generalNotes);
+                CheckKillzone3Settings(serial, items, notes, generalNotes);
             }
             else if (items["game_title"] == "vsh.self")
                 CheckVshSettings(items, notes, generalNotes);
@@ -898,6 +899,28 @@ namespace CompatBot.Utils.ResultFormatters
                 }
             }
         }
+
+        private static readonly HashSet<string> Killzone3Ids = new HashSet<string>
+        {
+            "BCAS20066", "BCES00081", "BCUS98116", "NPUA98116", "NPUA70034",
+            "NPJA90092", "NPEA90034", "NPUA70034",
+        };
+
+        private static void CheckKillzone3Settings(string serial, NameValueCollection items, List<string> notes)
+        {
+            if (!Killzone3Ids.Contains(serial))
+                return;
+
+            if (ppuPatches.Any() && patchNames.Count(n => n.Contains("Disable MLAA", StringComparison.OrdinalIgnoreCase)) > 1) // when MLAA patch is applied
+            {
+                if (items["write_color_buffers"] == EnabledMark)
+                    notes.Add("⚠ `Write Color Buffers` is not required with applied MLAA patch");
+            }
+            else
+            {
+                if (items["write_color_buffers"] == DisabledMark)
+                    notes.Add("⚠ Please enable MLAA patch (Recommended) or `Write Color Buffers`");
+            }
 
         private static readonly HashSet<string> RdrIds = new HashSet<string>
         {

--- a/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.WeirdSettingsSection.cs
+++ b/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.WeirdSettingsSection.cs
@@ -31,8 +31,6 @@ namespace CompatBot.Utils.ResultFormatters
             items["has_tsx_fa"] = hasTsxFa ? EnabledMark : DisabledMark;
             if (items["enable_tsx"] == "Disabled" && hasTsx && !hasTsxFa)
                 notes.Add("ℹ TSX support is disabled");
-            else if (items["enable_tsx"] == "Enabled" && hasTsxFa)
-                notes.Add("⚠ Disable TSX support if you experience performance issues");
             if (items["spu_lower_thread_priority"] == EnabledMark
                 && threadCount > 4)
                 notes.Add("❔ `Lower SPU thread priority` is enabled on a CPU with enough threads");

--- a/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.WeirdSettingsSection.cs
+++ b/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.WeirdSettingsSection.cs
@@ -31,7 +31,7 @@ namespace CompatBot.Utils.ResultFormatters
             items["has_tsx_fa"] = hasTsxFa ? EnabledMark : DisabledMark;
             if (items["enable_tsx"] == "Disabled" && hasTsx && TsxFaFixedVersion && !hasTsxFa)
                 notes.Add("ℹ TSX support is disabled");
-            else if (items["enable_tsx"] == "Enabled" && hasTsxFa)
+            else if (items["enable_tsx"] == "Enabled" && hasTsxFa && !TsxFaFixedVersion)
                 notes.Add("⚠ Disable TSX support if you experience performance issues");
             if (items["spu_lower_thread_priority"] == EnabledMark
                 && threadCount > 4)

--- a/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.WeirdSettingsSection.cs
+++ b/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.WeirdSettingsSection.cs
@@ -872,6 +872,16 @@ namespace CompatBot.Utils.ResultFormatters
                 if (items["read_depth_buffer"] == DisabledMark)
                     notes.Add("⚠ Please enable `Read Depth Buffer` or appropriate patches");
             }
+            if (ppuPatches.Any() && patchNames.Count(n => n.Contains("Disable in-built MLAA", StringComparison.OrdinalIgnoreCase)) > 1) // when MLAA patch is applied
+            {
+                if (items["write_color_buffers"] == EnabledMark)
+                    notes.Add("⚠ `Write Color Buffers` is not required with applied MLAA patch");
+            }
+            else
+            {
+                if (items["write_color_buffers"] == DisabledMark)
+                    notes.Add("⚠ Please enable MLAA patch (Recommended) or `Write Color Buffers`");
+            }
             if (items["resolution_scale"] is string resFactor
                 && int.TryParse(resFactor, out var resolutionScale))
             {

--- a/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.WeirdSettingsSection.cs
+++ b/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.WeirdSettingsSection.cs
@@ -903,7 +903,9 @@ namespace CompatBot.Utils.ResultFormatters
         private static readonly HashSet<string> Killzone3Ids = new HashSet<string>
         {
             "BCAS20066", "BCES00081", "BCUS98116", "NPUA98116", "NPUA70034",
-            "NPJA90092", "NPEA90034", "NPUA70034",
+            "BCES01007", "BCAS25008", "BCJS30066", "BCJS37003", "BCJS75002",
+            "BCUS98234", "NPJA90092", "NPEA90034", "NPUA70034", "NPEA90084",
+            "NPJA90178", "NPUA70133", "NPHA80140", "NPEA90085",
         };
 
         private static void CheckKillzone3Settings(string serial, NameValueCollection items, List<string> notes)
@@ -921,7 +923,7 @@ namespace CompatBot.Utils.ResultFormatters
                 if (items["write_color_buffers"] == DisabledMark)
                     notes.Add("⚠ Please enable MLAA patch (Recommended) or `Write Color Buffers`");
             }
-
+        }
         private static readonly HashSet<string> RdrIds = new HashSet<string>
         {
             "BLAS50296", "BLES00680", "BLES01179", "BLES01294", "BLUS30418", "BLUS30711", "BLUS30758",

--- a/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.cs
+++ b/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.cs
@@ -57,6 +57,7 @@ namespace CompatBot.Utils.ResultFormatters
         private static readonly Version AmdRecommendedOldWindowsVersion = new Version(20, 1, 4);
         private static readonly Version AmdLastGoodOpenGLWindowsVersion = new Version(20, 1, 4);
         private static readonly Version NvidiaFullscreenBugFixed = new Version(0, 0, 6, 8204);
+        private static readonly Version TsxFaFixedVersion  = new Version(0, 0, 12, 10995);
 
         private static readonly Dictionary<string, string> RsxPresentModeMap = new Dictionary<string, string>
         {

--- a/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.cs
+++ b/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.cs
@@ -120,17 +120,21 @@ namespace CompatBot.Utils.ResultFormatters
             "BLES00932", "BLUS30443", "BCJS70013", "BCJS30022", // DeS
             "BLUS30481", "BLES00826", "BLJM60223", // Nier
             "BCAS25003", "BCES00510", "BCES00516", "BCES00799", "BCJS37001", "BCUS98111", "BCKS15003", "NPUA70080", // God of War 3 / Demo
+            "BCUS98167", "BCJS30041", "BCES00701", "NPUA80535", "NPEA00291", // Modnation Racers
+            "NPUA70096", "NPEA90062", // Modnation Racers demos
+            "NPUA70074", // Modnation Racers beta
+            "BCES01422", "BCUS98254", "NPUA80848", "NPEA00421", "NPHA80239", // LittleBigPlanet Karting
+            "NPJA90244", "NPEA90117", "NPUA70249", // LittleBigPlanet Karting demo
+            "BCAS20066", "BCES00081", "BCUS98116", "NPUA98116", "NPUA70034", // Killzone 2
+            "NPJA90092", "NPEA90034", "NPUA70034", // Killzone 2 demo
             "BCES00006", "BCUS98137", "NPEA00333", "NPUA80499", // Motorstorm
             "BCES00484", "BCUS98242", "NPEA00315", "NPUA80661", // Motorstorm Apocalypse
             "BCES00129", "BCUS98155", // Motorstorm Pacific Rift
             "NPEA90090", "NPUA70140", "NPEA90033", // Motorstorm demos
             "BLJM60528", "NPJB00235", "NPHB00522", "NPJB90534", //E.X. Troopers / demo
+            "BLES01702", "BLJS10187", "BLUS31002", "NPEB01140", "NPJB00236", "NPUB30899", // Tekken Tag Tournament 2
             "BLES01987", "BLUS30964", "BLJS10160", // The Witch and the Hundred Knight
             "BCAS20100", "BCES00664", "NPEA00057", "NPJA00031", "NPUA80105", // wipeout hd
-            "BCAS20270", "BCES01584", "BCES01585", "BCJS37010", "BCUS98174", // tlou
-            "NPEA00435", "NPEA00521", "NPJA00096", "NPJA00129",// tlou
-            "NPUA30134", "NPUA70257", "NPUA80960", "NPUA81175",// tlou
-            "NPHA80206", "NPHA80279",// tlou
 
         };
 


### PR DESCRIPTION
Remove recommendation to disable TSX when user has TSX-FA. No-longer needed after https://github.com/RPCS3/rpcs3/pull/9048
Add more games that are known to require WCB
Add check for TLoU, WCB is only required when not using MLAA patch
Add check for Killzone 3, WCB is only required when not using MLAA patch.

