### PR TITLE
Workaround the bug that was unmasked after moving to new json serializer

### DIFF
--- a/Clients/CompatApiClient/Client.cs
+++ b/Clients/CompatApiClient/Client.cs
@@ -26,6 +26,7 @@ namespace CompatApiClient
                 PropertyNamingPolicy = SpecialJsonNamingPolicy.SnakeCase,
                 IgnoreNullValues = true,
                 IncludeFields = true,
+                Converters = { new CompatApiCommitHashConverter(), },
             };
         }
 

--- a/Clients/CompatApiClient/Formatters/CompatApiCommitHashConverter.cs
+++ b/Clients/CompatApiClient/Formatters/CompatApiCommitHashConverter.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace CompatApiClient
+{
+    public sealed class CompatApiCommitHashConverter : JsonConverter<string>
+    {
+        public override string? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Number
+                && !reader.HasValueSequence
+                && reader.ValueSpan.Length == 1
+                && reader.ValueSpan[0] == (byte)'0')
+            {
+                _ = reader.GetInt32();
+                return null;
+            }
+
+            return reader.GetString();
+        }
+
+        public override void Write(Utf8JsonWriter writer, string value, JsonSerializerOptions options)
+            => writer.WriteStringValue(value);
+    }
+}

--- a/CompatBot/EventHandlers/ProductCodeLookup.cs
+++ b/CompatBot/EventHandlers/ProductCodeLookup.cs
@@ -107,6 +107,7 @@ namespace CompatBot.EventHandlers
             if (string.IsNullOrEmpty(code))
                 return TitleInfo.Unknown.AsEmbed(code, gameTitle, forLog);
 
+            string? thumbnailUrl = null;
             try
             {
                 var result = await CompatClient.GetCompatResultAsync(RequestBuilder.Start().SetSearch(code), Config.Cts.Token).ConfigureAwait(false);
@@ -116,7 +117,7 @@ namespace CompatBot.EventHandlers
                 if (result?.ReturnCode == -1)
                     return TitleInfo.CommunicationError.AsEmbed(code);
 
-                var thumbnailUrl = await client.GetThumbnailUrlAsync(code).ConfigureAwait(false);
+                thumbnailUrl = await client.GetThumbnailUrlAsync(code).ConfigureAwait(false);
 
                 if (result?.Results != null && result.Results.TryGetValue(code, out var info))
                     return info.AsEmbed(code, gameTitle, forLog, thumbnailUrl);
@@ -150,7 +151,7 @@ namespace CompatBot.EventHandlers
             catch (Exception e)
             {
                 Config.Log.Warn(e, $"Couldn't get compat result for {code}");
-                return TitleInfo.CommunicationError.AsEmbed(null);
+                return TitleInfo.CommunicationError.AsEmbed(code, gameTitle, forLog, thumbnailUrl);
             }
         }
 


### PR DESCRIPTION
and try to show cached data when there's an error communicating with compat api