### PR TITLE
Remove SPU loop detection warning for DeS

### DIFF
--- a/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.WeirdSettingsSection.cs
+++ b/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.WeirdSettingsSection.cs
@@ -761,9 +761,6 @@ namespace CompatBot.Utils.ResultFormatters
             if (items["frame_limit"] is string frameLimit && frameLimit != "Off")
                 notes.Add("⚠ `Frame Limiter` should be `Off`");
 
-            if (items["spu_loop_detection"] == EnabledMark)
-                notes.Add("⚠ `SPU Loop Detection` is `Enabled`, and can cause visual artifacts");
-
             if (items["spu_threads"] is string spuThreads && spuThreads != "Auto")
                 notes.Add("⚠ Please set `SPU Thread Count` to `Auto` for best performance");
 


### PR DESCRIPTION
Is this actually a problem anymore? Feel free to close if this is still a legitimate problem in modern versions of RPCS3 or you want to do it differently.