### PR TITLE
Update handling of bot usage stats

### DIFF
--- a/CompatBot/Commands/BaseCommandModuleCustom.cs
+++ b/CompatBot/Commands/BaseCommandModuleCustom.cs
@@ -63,8 +63,7 @@ internal class BaseCommandModuleCustom : BaseCommandModule
     {
         if (ctx.Command?.QualifiedName is string qualifiedName)
         {
-            StatsStorage.CmdStatCache.TryGetValue(qualifiedName, out int counter);
-            StatsStorage.CmdStatCache.Set(qualifiedName, ++counter, StatsStorage.CacheTime);
+            StatsStorage.IncCmdStat(qualifiedName);
             Config.TelemetryClient?.TrackRequest(qualifiedName, executionStart, DateTimeOffset.UtcNow - executionStart, HttpStatusCode.OK.ToString(), true);
         }
 

--- a/CompatBot/Commands/BotStats.cs
+++ b/CompatBot/Commands/BotStats.cs
@@ -171,12 +171,7 @@ internal sealed class BotStats: BaseCommandModuleCustom
 
     private static void AppendCmdStats(DiscordEmbedBuilder embed)
     {
-        var commandStats = StatsStorage.CmdStatCache.GetCacheKeys<string>();
-        var sortedCommandStats = commandStats
-            .Select(c => (name: c, stat: StatsStorage.CmdStatCache.Get(c) as int?))
-            .Where(c => c.stat.HasValue)
-            .OrderByDescending(c => c.stat)
-            .ToList();
+        var sortedCommandStats = StatsStorage.GetCmdStats();
         var totalCalls = sortedCommandStats.Sum(c => c.stat);
         var top = sortedCommandStats.Take(5).ToList();
         if (top.Count == 0)
@@ -192,12 +187,7 @@ internal sealed class BotStats: BaseCommandModuleCustom
 
     private static void AppendExplainStats(DiscordEmbedBuilder embed)
     {
-        var terms = StatsStorage.ExplainStatCache.GetCacheKeys<string>();
-        var sortedTerms = terms
-            .Select(t => (term: t, stat: StatsStorage.ExplainStatCache.Get(t) as int?))
-            .Where(t => t.stat.HasValue)
-            .OrderByDescending(t => t.stat)
-            .ToList();
+        var sortedTerms = StatsStorage.GetExplainStats();
         var totalExplains = sortedTerms.Sum(t => t.stat);
         var top = sortedTerms.Take(5).ToList();
         if (top.Count == 0)
@@ -213,12 +203,7 @@ internal sealed class BotStats: BaseCommandModuleCustom
 
     private static void AppendGameLookupStats(DiscordEmbedBuilder embed)
     {
-        var gameTitles = StatsStorage.GameStatCache.GetCacheKeys<string>();
-        var sortedTitles = gameTitles
-            .Select(t => (title: t, stat: StatsStorage.GameStatCache.Get(t) as int?))
-            .Where(t => t.stat.HasValue)
-            .OrderByDescending(t => t.stat)
-            .ToList();
+        var sortedTitles = StatsStorage.GetGameStats();
         var totalLookups = sortedTitles.Sum(t => t.stat);
         var top = sortedTitles.Take(5).ToList();
         if (top.Count == 0)

--- a/CompatBot/Commands/CompatList.cs
+++ b/CompatBot/Commands/CompatList.cs
@@ -508,10 +508,7 @@ internal sealed class CompatList : BaseCommandModuleCustom
                                                        || (t.info.Title?.StartsWith(searchTerm, StringComparison.InvariantCultureIgnoreCase) ?? false)
                                                        || (t.info.AlternativeTitle?.StartsWith(searchTerm, StringComparison.InvariantCultureIgnoreCase) ?? false));
                 foreach (var title in searchHits.Select(t => t.info.Title).Distinct())
-                {
-                    StatsStorage.GameStatCache.TryGetValue(title, out int stat);
-                    StatsStorage.GameStatCache.Set(title, ++stat, StatsStorage.CacheTime);
-                }
+                    StatsStorage.IncGameStat(title);
                 foreach (var resultInfo in sortedList.Take(request.AmountRequested))
                 {
                     var info = resultInfo.AsString();

--- a/CompatBot/Commands/Explain.cs
+++ b/CompatBot/Commands/Explain.cs
@@ -397,8 +397,7 @@ internal sealed class Explain: BaseCommandModuleCustom
                 }
 
                 var explain = termLookupResult.explanation;
-                StatsStorage.ExplainStatCache.TryGetValue(explain.Keyword, out int stat);
-                StatsStorage.ExplainStatCache.Set(explain.Keyword, ++stat, StatsStorage.CacheTime);
+                StatsStorage.IncExplainStat(explain.Keyword);
                 msgBuilder = new DiscordMessageBuilder().WithContent(explain.Text);
                 if (!usedReply && useReply)
                     msgBuilder.WithReply(sourceMessage.Id);

--- a/CompatBot/CompatBot.csproj
+++ b/CompatBot/CompatBot.csproj
@@ -39,10 +39,10 @@
     <AdditionalFiles Include="..\win32_error_codes.txt" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="DSharpPlus" Version="4.3.0-nightly-01149" />
-    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.3.0-nightly-01149" />
-    <PackageReference Include="DSharpPlus.Interactivity" Version="4.3.0-nightly-01149" />
-    <PackageReference Include="DSharpPlus.SlashCommands" Version="4.3.0-nightly-01149" />
+    <PackageReference Include="DSharpPlus" Version="4.3.0-nightly-01146" />
+    <PackageReference Include="DSharpPlus.CommandsNext" Version="4.3.0-nightly-01146" />
+    <PackageReference Include="DSharpPlus.Interactivity" Version="4.3.0-nightly-01146" />
+    <PackageReference Include="DSharpPlus.SlashCommands" Version="4.3.0-nightly-01146" />
     <PackageReference Include="Google.Apis.Drive.v3" Version="1.57.0.2684" />
     <PackageReference Include="ksemenenko.ColorThief" Version="1.1.1.4" />
     <PackageReference Include="MathParser.org-mXparser" Version="5.0.6" />

--- a/CompatBot/Database/BotDb.cs
+++ b/CompatBot/Database/BotDb.cs
@@ -44,7 +44,7 @@ internal class BotDb: DbContext
         modelBuilder.Entity<DisabledCommand>().HasIndex(c => c.Command).IsUnique().HasDatabaseName("disabled_command_command");
         modelBuilder.Entity<WhitelistedInvite>().HasIndex(i => i.GuildId).IsUnique().HasDatabaseName("whitelisted_invite_guild_id");
         modelBuilder.Entity<EventSchedule>().HasIndex(e => new {e.Year, e.EventName}).HasDatabaseName("event_schedule_year_event_name");
-        modelBuilder.Entity<Stats>().HasIndex(s => new { s.Category, s.Key }).IsUnique().HasDatabaseName("stats_category_key");
+        modelBuilder.Entity<Stats>().HasIndex(s => new { s.Category, s.Bucket, s.Key }).IsUnique().HasDatabaseName("stats_category_bucket_key");
         modelBuilder.Entity<Kot>().HasIndex(k => k.UserId).IsUnique().HasDatabaseName("kot_user_id");
         modelBuilder.Entity<Doggo>().HasIndex(d => d.UserId).IsUnique().HasDatabaseName("doggo_user_id");
         modelBuilder.Entity<ForcedNickname>().HasIndex(d => new { d.GuildId, d.UserId }).IsUnique().HasDatabaseName("forced_nickname_guild_id_user_id");
@@ -169,6 +169,7 @@ internal class Stats
     public int Id { get; set; }
     [Required]
     public string Category { get; set; } = null!;
+    public string? Bucket { get; set; }
     [Required]
     public string Key { get; set; } = null!;
     public int Value { get; set; }

--- a/CompatBot/Database/Migrations/BotDb/20220704163631_AddStatsBucketColumn.Designer.cs
+++ b/CompatBot/Database/Migrations/BotDb/20220704163631_AddStatsBucketColumn.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using CompatBot.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,10 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CompatBot.Database.Migrations
 {
     [DbContext(typeof(BotDb))]
-    partial class BotDbModelSnapshot : ModelSnapshot
+    [Migration("20220704163631_AddStatsBucketColumn")]
+    partial class AddStatsBucketColumn
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "6.0.6");

--- a/CompatBot/Database/Migrations/BotDb/20220704163631_AddStatsBucketColumn.cs
+++ b/CompatBot/Database/Migrations/BotDb/20220704163631_AddStatsBucketColumn.cs
@@ -1,0 +1,45 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CompatBot.Database.Migrations
+{
+    public partial class AddStatsBucketColumn : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "stats_category_key",
+                table: "stats");
+
+            migrationBuilder.AddColumn<string>(
+                name: "bucket",
+                table: "stats",
+                type: "TEXT",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "stats_category_bucket_key",
+                table: "stats",
+                columns: new[] { "category", "bucket", "key" },
+                unique: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "stats_category_bucket_key",
+                table: "stats");
+
+            migrationBuilder.DropColumn(
+                name: "bucket",
+                table: "stats");
+
+            migrationBuilder.CreateIndex(
+                name: "stats_category_key",
+                table: "stats",
+                columns: new[] { "category", "key" },
+                unique: true);
+        }
+    }
+}

--- a/CompatBot/EventHandlers/IsTheGamePlayableHandler.cs
+++ b/CompatBot/EventHandlers/IsTheGamePlayableHandler.cs
@@ -32,7 +32,7 @@ internal static class IsTheGamePlayableHandler
 
     public static async Task OnMessageCreated(DiscordClient c, MessageCreateEventArgs args)
     {
-        if (DefaultHandlerFilter.IsFluff(args.Message))
+        if (DefaultHandlerFilter.IsFluff(args.Message) || args.Channel is null)
             return;
 
 #if !DEBUG

--- a/CompatBot/EventHandlers/IsTheGamePlayableHandler.cs
+++ b/CompatBot/EventHandlers/IsTheGamePlayableHandler.cs
@@ -125,10 +125,7 @@ internal static class IsTheGamePlayableHandler
                 return (null, null);
 
             if (!string.IsNullOrEmpty(info.Title))
-            {
-                StatsStorage.GameStatCache.TryGetValue(info.Title, out int stat);
-                StatsStorage.GameStatCache.Set(info.Title, ++stat, StatsStorage.CacheTime);
-            }
+                StatsStorage.IncGameStat(info.Title);
             return (code, info);
         }
         catch (Exception e)

--- a/CompatBot/Utils/ResultFormatters/TitleInfoFormatter.cs
+++ b/CompatBot/Utils/ResultFormatters/TitleInfoFormatter.cs
@@ -102,10 +102,7 @@ internal static class TitleInfoFormatter
                 desc += " (cached)";
             var cacheTitle = info.Title ?? gameTitle;
             if (!string.IsNullOrEmpty(cacheTitle))
-            {
-                StatsStorage.GameStatCache.TryGetValue(cacheTitle, out int stat);
-                StatsStorage.GameStatCache.Set(cacheTitle, ++stat, StatsStorage.CacheTime);
-            }
+                StatsStorage.IncGameStat(cacheTitle);
             var title = $"{productCodePart}{cacheTitle?.Trim(200)}{onlineOnlyPart}";
             if (string.IsNullOrEmpty(title))
                 desc = "";
@@ -143,8 +140,7 @@ internal static class TitleInfoFormatter
                 gameTitle = titleName;
             if (!string.IsNullOrEmpty(gameTitle))
             {
-                StatsStorage.GameStatCache.TryGetValue(gameTitle, out int stat);
-                StatsStorage.GameStatCache.Set(gameTitle, ++stat, StatsStorage.CacheTime);
+                StatsStorage.IncGameStat(gameTitle);
                 result.Title = $"{productCodePart}{gameTitle.Sanitize().Trim(200)}";
             }
             return result;


### PR DESCRIPTION
* wrap everything inside the provider
* do hour-long buckets to workaround the long-standing issue of sticky data bias
* remove stale data on stats restore instead of nuking-n-paving on every stat save