### PR TITLE
Fix cache extension methods

### DIFF
--- a/CompatBot/Utils/Extensions/MemoryCacheExtensions.cs
+++ b/CompatBot/Utils/Extensions/MemoryCacheExtensions.cs
@@ -10,32 +10,50 @@ internal static class MemoryCacheExtensions
 {
     public static List<T> GetCacheKeys<T>(this MemoryCache memoryCache)
     {
-        var field = memoryCache.GetType()
+        var stateField = memoryCache.GetType()
+            .GetFields(BindingFlags.NonPublic | BindingFlags.Instance)
+            .FirstOrDefault(fi => fi.Name == "_coherentState");
+        var coherentState = stateField?.GetValue(memoryCache);
+        if (coherentState is null)
+        {
+            Config.Log.Error($"Looks like {nameof(MemoryCache)} internals have changed");
+            return new();
+        }
+
+        var field = coherentState.GetType()
             .GetFields(BindingFlags.NonPublic | BindingFlags.Instance)
             .FirstOrDefault(fi => fi.Name == "_entries");
-
         if (field is null)
         {
             Config.Log.Error($"Looks like {nameof(MemoryCache)} internals have changed");
-            return new List<T>();
+            return new();
         }
 
-        var value = (IDictionary?)field.GetValue(memoryCache);
+        var value = (IDictionary?)field.GetValue(coherentState);
         return value?.Keys.OfType<T>().ToList() ?? new List<T>();
     }
 
     public static Dictionary<TKey, ICacheEntry?> GetCacheEntries<TKey>(this MemoryCache memoryCache)
         where TKey: notnull
     {
-        var field = memoryCache.GetType()
+        var stateField = memoryCache.GetType()
+            .GetFields(BindingFlags.NonPublic | BindingFlags.Instance)
+            .FirstOrDefault(fi => fi.Name == "_coherentState");
+        var coherentState = stateField?.GetValue(memoryCache);
+        if (coherentState is null)
+        {
+            Config.Log.Error($"Looks like {nameof(MemoryCache)} internals have changed");
+            return new();
+        }
+
+        var field = coherentState.GetType()
             .GetFields(BindingFlags.NonPublic | BindingFlags.Instance)
             .FirstOrDefault(fi => fi.Name == "_entries");
-
-        var cacheEntries = (IDictionary?)field?.GetValue(memoryCache);
+        var cacheEntries = (IDictionary?)field?.GetValue(coherentState);
         if (cacheEntries is null)
         {
             Config.Log.Error($"Looks like {nameof(MemoryCache)} internals have changed");
-            return new Dictionary<TKey, ICacheEntry?>(0);
+            return new(0);
         }
 
         var result = new Dictionary<TKey, ICacheEntry?>(cacheEntries.Count);


### PR DESCRIPTION
Apparently MemoryCache class was changed in .NET 7 and I didn't trigger the check on local instance