### PR TITLE
Replace event date blocks

### DIFF
--- a/CompatBot/Commands/EventsBaseCommand.cs
+++ b/CompatBot/Commands/EventsBaseCommand.cs
@@ -266,13 +266,13 @@ internal class EventsBaseCommand: BaseCommandModuleCustom
                 var printName = string.IsNullOrEmpty(currentEvent) ? "Various independent events" : $"**{currentEvent} {currentYear} schedule**";
                 msg.AppendLine($"{printName} (UTC):");
             }
-            msg.Append(StringUtils.InvisibleSpacer).Append('`');
+            msg.Append(StringUtils.InvisibleSpacer);
             if (ModProvider.IsMod(ctx.Message.Author.Id))
-                msg.Append($"[{evt.Id:0000}] ");
-            msg.Append($"{evt.Start.AsUtc():u}");
+                msg.Append($"`[{evt.Id:0000}]` ");
+            msg.Append($"<t:{((DateTimeOffset)evt.Start.AsUtc()).ToUnixTimeSeconds():u}:f>");
             if (ctx.Channel.IsPrivate)
-                msg.Append($@" - {evt.End.AsUtc():u}");
-            msg.AppendLine($@" ({evt.End.AsUtc() - evt.Start.AsUtc():h\:mm})`: {evt.Name}");
+                msg.Append($@" - <t:{((DateTimeOffset)evt.End.AsUtc()).ToUnixTimeSeconds():u}:f>");
+            msg.AppendLine($@" ({evt.End.AsUtc() - evt.Start.AsUtc():h\:mm}): {evt.Name}");
         }
         var ch = await ctx.GetChannelForSpamAsync().ConfigureAwait(false);
         await ch.SendAutosplitMessageAsync(msg, blockStart: "", blockEnd: "").ConfigureAwait(false);

--- a/CompatBot/Commands/EventsBaseCommand.cs
+++ b/CompatBot/Commands/EventsBaseCommand.cs
@@ -269,9 +269,9 @@ internal class EventsBaseCommand: BaseCommandModuleCustom
             msg.Append(StringUtils.InvisibleSpacer);
             if (ModProvider.IsMod(ctx.Message.Author.Id))
                 msg.Append($"`[{evt.Id:0000}]` ");
-            msg.Append($"<t:{((DateTimeOffset)evt.Start.AsUtc()).ToUnixTimeSeconds():u}:f>");
+            msg.Append($"<t:{((DateTimeOffset)evt.Start.AsUtc()).ToUnixTimeSeconds()}:f>");
             if (ctx.Channel.IsPrivate)
-                msg.Append($@" - <t:{((DateTimeOffset)evt.End.AsUtc()).ToUnixTimeSeconds():u}:f>");
+                msg.Append($@" - <t:{((DateTimeOffset)evt.End.AsUtc()).ToUnixTimeSeconds()}:f>");
             msg.AppendLine($@" ({evt.End.AsUtc() - evt.Start.AsUtc():h\:mm}): {evt.Name}");
         }
         var ch = await ctx.GetChannelForSpamAsync().ConfigureAwait(false);


### PR DESCRIPTION
Why use UTC standardized time and date blocks for event list, when discord can show them relative to system's timezone. Much easier to know when it will happen.
How it looks:
![изображение](https://user-images.githubusercontent.com/24612088/225127752-94b1ccb9-769c-4660-8a83-c2bc70c25efb.png)

Although you still need to add events considering this factor. And I'm pretty sure there's a room to improve it further.