### PR TITLE
fix ird download link

### DIFF
--- a/Clients/IrdLibraryClient/IrdClient.cs
+++ b/Clients/IrdLibraryClient/IrdClient.cs
@@ -125,6 +125,6 @@ namespace IrdLibraryClient
             }
         }
         
-        public static Uri GetDownloadLink(string relativeLink) => new(BaseDownloadUri, relativeLink);
+        public static string GetDownloadLink(string relativeLink) => Uri.EscapeUriString(new Uri(BaseDownloadUri, relativeLink).ToString());
     }
 }

--- a/Clients/IrdLibraryClient/IrdClient.cs
+++ b/Clients/IrdLibraryClient/IrdClient.cs
@@ -125,6 +125,11 @@ namespace IrdLibraryClient
             }
         }
         
-        public static string GetDownloadLink(string relativeLink) => Uri.EscapeUriString(new Uri(BaseDownloadUri, relativeLink).ToString());
+        public static string GetDownloadLink(string relativeLink)
+        {
+            var encodedLink = Uri.EscapeDataString(relativeLink);
+            var fullUri = new Uri(BaseDownloadUri, encodedLink);
+            return fullUri.AbsoluteUri;
+        }
     }
 }


### PR DESCRIPTION
IRDs that have spaces and other characters like () didnt create a proper link