### PR TITLE
Properly escape ird download links without corrupting relative paths

### DIFF
--- a/Clients/IrdLibraryClient/IrdClient.cs
+++ b/Clients/IrdLibraryClient/IrdClient.cs
@@ -124,11 +124,16 @@ namespace IrdLibraryClient
                 return result;
             }
         }
-        
-        public static Uri GetDownloadLink(string relativeLink)
+
+        private static string EscapeSegments(string relativePath)
         {
-            var encodedLink = Uri.EscapeDataString(relativeLink);
-            return new(BaseDownloadUri, encodedLink);
+            var segments = relativePath.Split('/');
+            for (var i = 0; i < segments.Length; i++)
+                segments[i] = Uri.EscapeDataString(segments[i]);
+            return string.Join("/", segments);
         }
+        
+        public static Uri GetDownloadLink(string relativeLink) => new(BaseDownloadUri, EscapeSegments(relativeLink));
+        public static string GetEscapedDownloadLink(string relativeLink) => GetDownloadLink(relativeLink).AbsoluteUri;
     }
 }

--- a/CompatBot/Utils/ResultFormatters/IrdSearchResultFormatter.cs
+++ b/CompatBot/Utils/ResultFormatters/IrdSearchResultFormatter.cs
@@ -32,7 +32,7 @@ namespace CompatBot.Utils.ResultFormatters
                 {
                     result.AddField(
                         $"{item.Title.Sanitize().Trim(EmbedPager.MaxFieldTitleLength - 18)} [v{item.GameVer} FW {item.FwVer}]",
-                        $"[⏬ {Path.GetFileName(item.Link)}]({IrdClient.GetDownloadLink(item.Link)})"
+                        $"[⏬ {Path.GetFileName(item.Link).Replace("]", @"\]")}]({IrdClient.GetEscapedDownloadLink(item.Link)})"
                     );
                 }
                 catch (Exception e)

--- a/Tests/UriFormattingTests.cs
+++ b/Tests/UriFormattingTests.cs
@@ -1,0 +1,24 @@
+﻿using IrdLibraryClient;
+using NUnit.Framework;
+
+namespace Tests;
+
+[TestFixture]
+public class UriFormattingTests
+{
+    [TestCase("file with spaces.ird")]
+    [TestCase("file (with parenthesis).ird")]
+    [TestCase("file/with/segments.ird")]
+    public void IrdLinkFormatTest(string filename)
+    {
+        var uri = IrdClient.GetEscapedDownloadLink(filename);
+        Assert.Multiple(() =>
+        {
+            Assert.That(uri, Does.Not.Contains(" "));
+            Assert.That(uri, Does.Not.Contains("("));
+            Assert.That(uri, Does.Not.Contains(")"));
+            Assert.That(uri, Does.Not.Contains("%2F"));
+            Assert.That(uri, Does.EndWith(".ird"));
+        });
+    }
+}


### PR DESCRIPTION
Initial implementation was breaking discord link formatting, and the attempted fix broke links with relative paths.
This version should fix both cases, and comes with some tests for known issues.