### PR TITLE
Hotfixes, part 2

### DIFF
--- a/CompatBot/Commands/Misc.cs
+++ b/CompatBot/Commands/Misc.cs
@@ -271,7 +271,7 @@ internal static partial class Misc
 
     [Command("8ball")]
     [Description("Get ~~a random~~ an objectively best answer to your question")]
-    public static ValueTask EightBall(SlashCommandContext ctx, [Description("A yes or no question")] string question)
+    public static ValueTask EightBall(CommandContext ctx, [Description("A yes or no question")] string question)
     {
         var ephemeral = !ctx.Channel.IsSpamChannel() && !ctx.Channel.IsOfftopicChannel();
         question = question.ToLowerInvariant();
@@ -283,7 +283,9 @@ internal static partial class Misc
         lock (rng) answer = pool[rng.Next(pool.Count)];
         if (answer.StartsWith(':') && answer.EndsWith(':'))
             answer = ctx.Client.GetEmoji(answer, "🔮");
-        return ctx.RespondAsync(answer, ephemeral: ephemeral);
+        if (ctx is SlashCommandContext sctx)
+            return sctx.RespondAsync(answer, ephemeral: ephemeral);
+        return ctx.RespondAsync(answer);
     }
 
     [Command("when"), AllowedProcessors<TextCommandProcessor>]

--- a/CompatBot/Commands/Psn.Check.cs
+++ b/CompatBot/Commands/Psn.Check.cs
@@ -113,8 +113,7 @@ internal static partial class Psn
         {
             var btnId = e.Interaction.Data.CustomId;
             var parts = btnId.Split(':');
-            if (parts is not [_, {Length: >6} authorIdStr, { Length: 9 } productCode]
-                || !ulong.TryParse(authorIdStr, out var authorId))
+            if (parts is not [_, .., { Length: 9 } productCode])
             {
                 Config.Log.Warn("Invalid interaction id: " + btnId);
                 return;
@@ -122,14 +121,12 @@ internal static partial class Psn
 
             try
             {
-                if (e.User.Id != authorId)
-                    return;
-                    
                 await e.Interaction.CreateResponseAsync(
                     DiscordInteractionResponseType.ChannelMessageWithSource,
                     new DiscordInteractionResponseBuilder()
                         .AsEphemeral()
-                        .WithContent($"Use application command `/psn check updates {productCode}` to search for game updates")
+                        // /psn check updates product_code: BLUS30078
+                        .WithContent($"Use application command `/psn check updates product_code:{productCode}` to search for game updates")
                 ).ConfigureAwait(false);
             }
             catch (Exception ex)

--- a/CompatBot/Commands/Warnings.ContextMenus.cs
+++ b/CompatBot/Commands/Warnings.ContextMenus.cs
@@ -77,6 +77,8 @@ internal static class WarningsContextMenus
                 var userMsg = new DiscordMessageBuilder()
                     .WithContent(userMsgContent)
                     .AddMention(new UserMention(user.Id));
+                if (message is not null)
+                    userMsg.WithReply(message.Id, mention: true);
                 await ctx.Channel.SendMessageAsync(userMsg).ConfigureAwait(false);
             }
             await Warnings.ListUserWarningsAsync(ctx.Client, interaction, user.Id, user.Username.Sanitize()).ConfigureAwait(false);

--- a/CompatBot/Commands/Warnings.ContextMenus.cs
+++ b/CompatBot/Commands/Warnings.ContextMenus.cs
@@ -72,11 +72,11 @@ internal static class WarningsContextMenus
             {
                 var userMsgContent = $"""
                       User warning saved, {user.Mention} has {recent} recent warning{StringUtils.GetSuffix(recent)} ({total} total)
-                      Warned for: {reason}
+                      Warned for: {reason} by {ctx.User.Mention}
                       """;
                 var userMsg = new DiscordMessageBuilder()
                     .WithContent(userMsgContent)
-                    .AddMention(UserMention.All);
+                    .AddMention(new UserMention(user.Id));
                 await ctx.Channel.SendMessageAsync(userMsg).ConfigureAwait(false);
             }
             await Warnings.ListUserWarningsAsync(ctx.Client, interaction, user.Id, user.Username.Sanitize()).ConfigureAwait(false);

--- a/CompatBot/Commands/Warnings.cs
+++ b/CompatBot/Commands/Warnings.cs
@@ -31,11 +31,11 @@ internal static partial class Warnings
         {
             var userMsgContent = $"""
                   User warning saved, {user.Mention} has {recent} recent warning{StringUtils.GetSuffix(recent)} ({total} total)
-                  Warned for: {reason}
+                  Warned for: {reason} by {ctx.User.Mention}
                   """;
             var userMsg = new DiscordMessageBuilder()
                 .WithContent(userMsgContent)
-                .AddMention(UserMention.All);
+                .AddMention(new UserMention(user));
             await ctx.Channel.SendMessageAsync(userMsg).ConfigureAwait(false);
         }
         await ListUserWarningsAsync(ctx.Client, ctx.Interaction, user.Id, user.Username.Sanitize()).ConfigureAwait(false);

--- a/CompatBot/Config.cs
+++ b/CompatBot/Config.cs
@@ -91,6 +91,7 @@ internal static class Config
     public static double GameTitleMatchThreshold => config.GetValue(nameof(GameTitleMatchThreshold), 0.57);
     public static byte[] CryptoSalt => Convert.FromBase64String(config.GetValue(nameof(CryptoSalt), ""));
     public static bool EnableEfDebugLogging => config.GetValue(nameof(EnableEfDebugLogging), false);
+    public static bool EnableBulkDiscordCommandOverwrite => config.GetValue(nameof(EnableBulkDiscordCommandOverwrite), false);
    
     internal static string CurrentLogPath => Path.GetFullPath(Path.Combine(LogPath, "bot.log"));
 
@@ -143,8 +144,8 @@ internal static class Config
 
     public static class Reactions
     {
-        public static readonly DiscordEmoji Success = DiscordEmoji.FromUnicode("👌");
-        public static readonly DiscordEmoji Failure = DiscordEmoji.FromUnicode("⛔");
+        public static readonly DiscordEmoji Success = DiscordEmoji.FromUnicode("✅");
+        public static readonly DiscordEmoji Failure = DiscordEmoji.FromUnicode("❌");
         public static readonly DiscordEmoji Denied = DiscordEmoji.FromUnicode("👮");
         public static readonly DiscordEmoji Starbucks = DiscordEmoji.FromUnicode("☕");
         public static readonly DiscordEmoji Moderated = DiscordEmoji.FromUnicode("🔨");

--- a/CompatBot/Config.cs
+++ b/CompatBot/Config.cs
@@ -57,7 +57,7 @@ internal static class Config
     public static TimeSpan SocketDisconnectCheckIntervalInSec => TimeSpan.FromSeconds(config.GetValue(nameof(SocketDisconnectCheckIntervalInSec), 10));
     public static TimeSpan LogParsingTimeoutInSec => TimeSpan.FromSeconds(config.GetValue(nameof(LogParsingTimeoutInSec), 30));
     public static TimeSpan BuildTimeDifferenceForOutdatedBuildsInDays => TimeSpan.FromDays(config.GetValue(nameof(BuildTimeDifferenceForOutdatedBuildsInDays), 3));
-    public static TimeSpan ShutupTimeLimitInMin => TimeSpan.FromMinutes(config.GetValue(nameof(ShutupTimeLimitInMin), 5));
+    public static TimeSpan ShutupTimeLimitInMin => TimeSpan.FromMinutes(config.GetValue(nameof(ShutupTimeLimitInMin), 15));
     public static TimeSpan ForcedNicknamesRecheckTimeInHours => TimeSpan.FromHours(config.GetValue(nameof(ForcedNicknamesRecheckTimeInHours), 3));
     public static TimeSpan IncomingMessageCheckIntervalInMin => TimeSpan.FromMinutes(config.GetValue(nameof(IncomingMessageCheckIntervalInMin), 10));
     public static TimeSpan MetricsIntervalInSec => TimeSpan.FromSeconds(config.GetValue(nameof(MetricsIntervalInSec), 10));

--- a/CompatBot/Database/Providers/ContentFilter.cs
+++ b/CompatBot/Database/Providers/ContentFilter.cs
@@ -232,12 +232,16 @@ internal static class ContentFilter
                     message.Content.Sanitize()
                 ).ConfigureAwait(false);
                 if (saved && !suppress && message.Channel is not null)
-                    await message.Channel.SendMessageAsync(
-                        $"""
-                         User warning saved, {message.Author.Mention} has {recent} recent warning{StringUtils.GetSuffix(recent)} ({total} total)
-                         Warned for: {warningReason}
-                         """
-                    ).ConfigureAwait(false);
+                {
+                    var msg = new DiscordMessageBuilder()
+                        .WithContent(
+                            $"""
+                             User warning saved, {message.Author.Mention} has {recent} recent warning{StringUtils.GetSuffix(recent)} ({total} total)
+                             Warned for: {warningReason} by {client.CurrentUser}
+                             """
+                        ).AddMention(new UserMention(message.Author));
+                    await message.Channel.SendMessageAsync(msg).ConfigureAwait(false);
+                }
                 completedActions.Add(FilterAction.IssueWarning);
             }
             catch (Exception e)

--- a/CompatBot/EventHandlers/DiscordInviteFilter.cs
+++ b/CompatBot/EventHandlers/DiscordInviteFilter.cs
@@ -129,12 +129,16 @@ internal static partial class DiscordInviteFilter
                         codeResolveMsg
                     ).ConfigureAwait(false);
                     if (saved && !suppress)
-                        await message.Channel.SendMessageAsync(
-                            $"""
-                             User warning saved, {message.Author.Mention} has {recent} recent warning{StringUtils.GetSuffix(recent)} ({total} total)
-                             Warned for: {reason}
-                             """
-                        ).ConfigureAwait(false);
+                    {
+                        var msg = new DiscordMessageBuilder()
+                            .WithContent(
+                                $"""
+                                 User warning saved, {message.Author.Mention} has {recent} recent warning{StringUtils.GetSuffix(recent)} ({total} total)
+                                 Warned for: {reason} by {client.CurrentUser}
+                                 """
+                            ).AddMention(new UserMention(message.Author));
+                        await message.Channel.SendMessageAsync(msg).ConfigureAwait(false);
+                    }
                 }
                 return false;
             }

--- a/CompatBot/EventHandlers/LogParsingHandler.cs
+++ b/CompatBot/EventHandlers/LogParsingHandler.cs
@@ -217,12 +217,16 @@ public static class LogParsingHandler
                                             $"{result.SelectedFilter.String} - {result.SelectedFilterContext?.Sanitize()}"
                                         );
                                         if (saved && !suppress)
-                                            await message.Channel.SendMessageAsync(
-                                                $"""
-                                                 User warning saved, {message.Author.Mention} has {recent} recent warning{StringUtils.GetSuffix(recent)} ({total} total)
-                                                 Warned for: {reason}
-                                                 """
-                                            ).ConfigureAwait(false);
+                                        {
+                                            var msg = new DiscordMessageBuilder()
+                                                .WithContent(
+                                                    $"""
+                                                     User warning saved, {message.Author.Mention} has {recent} recent warning{StringUtils.GetSuffix(recent)} ({total} total)
+                                                     Warned for: {reason} by {client.CurrentUser}
+                                                     """
+                                                ).AddMention(new UserMention(message.Author));
+                                            await message.Channel.SendMessageAsync(msg).ConfigureAwait(false);
+                                        }
                                     }
                                 }
                             }

--- a/CompatBot/EventHandlers/ProductCodeLookup.cs
+++ b/CompatBot/EventHandlers/ProductCodeLookup.cs
@@ -50,7 +50,6 @@ internal static partial class ProductCodeLookup
         await message.ReactWithAsync(Config.Reactions.PleaseWait).ConfigureAwait(false);
         try
         {
-            var lookupEmoji = new DiscordComponentEmoji(DiscordEmoji.FromUnicode("🔍"));
             var formattedResults = await LookupProductCodeAndFormatAsync(client, codesToLookup).ConfigureAwait(false);
             foreach (var result in formattedResults)
                 try
@@ -61,9 +60,9 @@ internal static partial class ProductCodeLookup
                         messageBuilder.AddComponents(
                             new DiscordButtonComponent(
                                 DiscordButtonStyle.Secondary,
-                                $"{GlobalButtonHandler.ReplaceWithUpdatesPrefix}{message.Author.Id}:{result.code}",
-                                "Check for updates",
-                                emoji: lookupEmoji
+                                $"{GlobalButtonHandler.ReplaceWithUpdatesPrefix}{result.code}",
+                                "How to check for updates",
+                                emoji: new(DiscordEmoji.FromUnicode("ℹ️"))
                             )
                         );
                     await DiscordMessageExtensions.UpdateOrCreateMessageAsync(null, channel, messageBuilder).ConfigureAwait(false);

--- a/CompatBot/EventHandlers/Starbucks.cs
+++ b/CompatBot/EventHandlers/Starbucks.cs
@@ -115,6 +115,8 @@ internal static class Starbucks
             message = await channel.GetMessageAsync(message.Id).ConfigureAwait(false);
             if (emoji == Config.Reactions.Starbucks)
                 await CheckMediaTalkAsync(client, channel, message, emoji).ConfigureAwait(false);
+            if (emoji == Config.Reactions.ShutUp && !isBacklog)
+                await ShutupAsync(client, user, message).ConfigureAwait(false);
             await CheckGameFansAsync(client, channel, message).ConfigureAwait(false);
         }
         catch (Exception e)
@@ -157,6 +159,20 @@ internal static class Starbucks
 
         await message.ReactWithAsync(emoji).ConfigureAwait(false);
         await client.ReportAsync(Config.Reactions.Starbucks + " Media talk report", message, reporters, null, ReportSeverity.Medium).ConfigureAwait(false);
+    }
+
+    private static async ValueTask ShutupAsync(DiscordClient client, DiscordUser user, DiscordMessage message)
+    {
+        if (message.Author is null || message.Author.IsCurrent is false)
+            return;
+
+        if (message.CreationTimestamp.Add(Config.ShutupTimeLimitInMin) < DateTime.UtcNow)
+            return;
+
+        if (!await user.IsWhitelistedAsync(client, message.Channel?.Guild).ConfigureAwait(false))
+            return;
+
+        await message.DeleteAsync().ConfigureAwait(false);
     }
 
     private static async ValueTask CheckGameFansAsync(DiscordClient client, DiscordChannel channel, DiscordMessage message)

--- a/CompatBot/Program.cs
+++ b/CompatBot/Program.cs
@@ -152,9 +152,7 @@ internal static class Program
                     {
                         //NamingPolicy = new CamelCaseNamingPolicy(),
                         RegisterCommands = true,
-#if DEBUG
-                        //UnconditionallyOverwriteCommands = true,
-#endif
+                        UnconditionallyOverwriteCommands = Config.EnableBulkDiscordCommandOverwrite,
                     });
                     textCommandProcessor.AddConverter<TextOnlyDiscordChannelConverter>();
                     extension.AddProcessor(textCommandProcessor);


### PR DESCRIPTION
- Reply to original message when using warn context menu on a message
- Restore bot muting with emoji reaction
- Better handling of unknown text commands
- Make `Check for updates` button on game info embed to work for everyone and change hint to work with slash commands by copy/paste
- Add bot config to use bulk command overwrite on startup
- Add mention of who warned the user in the user message