### PR TITLE
Try to fix sporadic exceptions from SQLite (Error 5: 'database is locked')

### DIFF
--- a/CompatBot/Commands/Audit.cs
+++ b/CompatBot/Commands/Audit.cs
@@ -142,10 +142,11 @@ internal static class Audit
                 try
                 {
                     var displayName = member.DisplayName;
-                    if (!UsernameZalgoMonitor.NeedsRename(displayName))
+                    if (!await UsernameZalgoMonitor.NeedsRenameAsync(displayName).ConfigureAwait(false))
                         continue;
 
-                    var nickname = UsernameZalgoMonitor.StripZalgo(displayName, member.Username, member.Id).Sanitize();
+                    var nickname = await UsernameZalgoMonitor.StripZalgoAsync(displayName, member.Username, member.Id).ConfigureAwait(false);
+                    nickname = nickname.Sanitize();
                     try
                     {
                         await member.ModifyAsync(m => m.Nickname = nickname).ConfigureAwait(false);

--- a/CompatBot/Commands/AutoCompleteProviders/BotConfigurationAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/BotConfigurationAutoCompleteProvider.cs
@@ -18,7 +18,7 @@ public class BotConfigurationAutoCompleteProvider: IAutoCompleteProvider
         if (!ModProvider.IsSudoer(context.User.Id))
             return [new($"{Config.Reactions.Denied} You are not authorized to use this command.", -1)];
 
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         IEnumerable<string> result;
         var input = context.UserInput;
         if (input is not { Length: > 0 })

--- a/CompatBot/Commands/AutoCompleteProviders/BotConfigurationAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/BotConfigurationAutoCompleteProvider.cs
@@ -18,7 +18,7 @@ public class BotConfigurationAutoCompleteProvider: IAutoCompleteProvider
         if (!ModProvider.IsSudoer(context.User.Id))
             return [new($"{Config.Reactions.Denied} You are not authorized to use this command.", -1)];
 
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         IEnumerable<string> result;
         var input = context.UserInput;
         if (input is not { Length: > 0 })

--- a/CompatBot/Commands/AutoCompleteProviders/ContentFilterAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/ContentFilterAutoCompleteProvider.cs
@@ -11,7 +11,7 @@ public class ContentFilterAutoCompleteProvider: IAutoCompleteProvider
         if (!ModProvider.IsMod(context.User.Id))
             return [new($"{Config.Reactions.Denied} You are not authorized to use this command.", -1)];
         
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         IEnumerable<(int id, string trigger)> result;
         if (context.UserInput is not {Length: >0} prefix)
             result = db.Piracystring

--- a/CompatBot/Commands/AutoCompleteProviders/ContentFilterAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/ContentFilterAutoCompleteProvider.cs
@@ -11,7 +11,7 @@ public class ContentFilterAutoCompleteProvider: IAutoCompleteProvider
         if (!ModProvider.IsMod(context.User.Id))
             return [new($"{Config.Reactions.Denied} You are not authorized to use this command.", -1)];
         
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         IEnumerable<(int id, string trigger)> result;
         if (context.UserInput is not {Length: >0} prefix)
             result = db.Piracystring

--- a/CompatBot/Commands/AutoCompleteProviders/EventIdAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/EventIdAutoCompleteProvider.cs
@@ -7,7 +7,7 @@ public class EventIdAutoCompleteProvider: IAutoCompleteProvider
 {
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
     {
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         IEnumerable<EventSchedule> query;
         if (context.UserInput is not { Length: > 0 } input)
         {

--- a/CompatBot/Commands/AutoCompleteProviders/EventIdAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/EventIdAutoCompleteProvider.cs
@@ -7,7 +7,7 @@ public class EventIdAutoCompleteProvider: IAutoCompleteProvider
 {
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
     {
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         IEnumerable<EventSchedule> query;
         if (context.UserInput is not { Length: > 0 } input)
         {

--- a/CompatBot/Commands/AutoCompleteProviders/EventNameAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/EventNameAutoCompleteProvider.cs
@@ -7,7 +7,7 @@ public class EventNameAutoCompleteProvider: IAutoCompleteProvider
 {
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
     {
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
 #if DEBUG        
         var currentTime = DateTime.UtcNow.AddYears(-10);
 #else

--- a/CompatBot/Commands/AutoCompleteProviders/EventNameAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/EventNameAutoCompleteProvider.cs
@@ -7,7 +7,7 @@ public class EventNameAutoCompleteProvider: IAutoCompleteProvider
 {
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
     {
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
 #if DEBUG        
         var currentTime = DateTime.UtcNow.AddYears(-10);
 #else

--- a/CompatBot/Commands/AutoCompleteProviders/ExplainAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/ExplainAutoCompleteProvider.cs
@@ -9,7 +9,7 @@ public class ExplainAutoCompleteProvider: IAutoCompleteProvider
 {
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
     {
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         IEnumerable<string> result;
         if (context.UserInput is not { Length: > 0 } prefix)
         {

--- a/CompatBot/Commands/AutoCompleteProviders/ExplainAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/ExplainAutoCompleteProvider.cs
@@ -9,7 +9,7 @@ public class ExplainAutoCompleteProvider: IAutoCompleteProvider
 {
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
     {
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         IEnumerable<string> result;
         if (context.UserInput is not { Length: > 0 } prefix)
         {

--- a/CompatBot/Commands/AutoCompleteProviders/InviteAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/InviteAutoCompleteProvider.cs
@@ -11,7 +11,7 @@ public class InviteAutoCompleteProvider: IAutoCompleteProvider
         if (!ModProvider.IsMod(context.User.Id))
             return [new($"{Config.Reactions.Denied} You are not authorized to use this command.", -1)];
         
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         IQueryable<WhitelistedInvite> result;
         if (context.UserInput is not { Length: > 0 } input)
             result = db.WhitelistedInvites

--- a/CompatBot/Commands/AutoCompleteProviders/InviteAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/InviteAutoCompleteProvider.cs
@@ -11,7 +11,7 @@ public class InviteAutoCompleteProvider: IAutoCompleteProvider
         if (!ModProvider.IsMod(context.User.Id))
             return [new($"{Config.Reactions.Denied} You are not authorized to use this command.", -1)];
         
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         IQueryable<WhitelistedInvite> result;
         if (context.UserInput is not { Length: > 0 } input)
             result = db.WhitelistedInvites

--- a/CompatBot/Commands/AutoCompleteProviders/ProductCodeAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/ProductCodeAutoCompleteProvider.cs
@@ -8,7 +8,7 @@ public class ProductCodeAutoCompleteProvider: IAutoCompleteProvider
 {
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
     {
-        await using var db = ThumbnailDb.OpenRead();
+        await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
         IEnumerable<(string code, string title)> result;
         if (context.UserInput is not { Length: > 0 } prefix)
         {

--- a/CompatBot/Commands/AutoCompleteProviders/ProductCodeAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/ProductCodeAutoCompleteProvider.cs
@@ -8,7 +8,7 @@ public class ProductCodeAutoCompleteProvider: IAutoCompleteProvider
 {
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
     {
-        await using var db = new ThumbnailDb();
+        await using var db = ThumbnailDb.OpenRead();
         IEnumerable<(string code, string title)> result;
         if (context.UserInput is not { Length: > 0 } prefix)
         {

--- a/CompatBot/Commands/AutoCompleteProviders/WarningAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/WarningAutoCompleteProvider.cs
@@ -20,7 +20,7 @@ public class WarningAutoCompleteProvider: IAutoCompleteProvider
                 ? w => w.Retracted && w.DiscordId == userId
                 : w => !w.Retracted && w.DiscordId == userId;
         
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         List<Warning> result;
         if (context.UserInput is not { Length: > 0 } prefix)
             result = await db.Warning

--- a/CompatBot/Commands/AutoCompleteProviders/WarningAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/WarningAutoCompleteProvider.cs
@@ -20,7 +20,7 @@ public class WarningAutoCompleteProvider: IAutoCompleteProvider
                 ? w => w.Retracted && w.DiscordId == userId
                 : w => !w.Retracted && w.DiscordId == userId;
         
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         List<Warning> result;
         if (context.UserInput is not { Length: > 0 } prefix)
             result = await db.Warning

--- a/CompatBot/Commands/Bot.Configuration.cs
+++ b/CompatBot/Commands/Bot.Configuration.cs
@@ -15,7 +15,7 @@ internal static partial class Bot
         [Description("List set variable names")]
         public static async ValueTask List(SlashCommandContext ctx)
         {
-            await using var db = BotDb.OpenRead();
+            await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
             var setVars = await db.BotState
                 .AsNoTracking()
                 .Where(v => v.Key.StartsWith(SqlConfiguration.ConfigVarPrefix))
@@ -49,7 +49,7 @@ internal static partial class Bot
             Config.InMemorySettings[key] = value;
             Config.RebuildConfiguration();
             key = SqlConfiguration.ConfigVarPrefix + key;
-            await using var db = BotDb.OpenRead();
+            await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
             var stateValue = await db.BotState.FirstOrDefaultAsync(v => v.Key == key).ConfigureAwait(false);
             if (stateValue == null)
             {
@@ -72,7 +72,7 @@ internal static partial class Bot
             Config.InMemorySettings.TryRemove(key, out _);
             Config.RebuildConfiguration();
             key = SqlConfiguration.ConfigVarPrefix + key;
-            await using var db = BotDb.OpenRead();
+            await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
             var stateValue = await db.BotState.Where(v => v.Key == key).FirstOrDefaultAsync().ConfigureAwait(false);
             if (stateValue is not null)
             {

--- a/CompatBot/Commands/Bot.Configuration.cs
+++ b/CompatBot/Commands/Bot.Configuration.cs
@@ -15,7 +15,7 @@ internal static partial class Bot
         [Description("List set variable names")]
         public static async ValueTask List(SlashCommandContext ctx)
         {
-            await using var db = new BotDb();
+            await using var db = BotDb.OpenRead();
             var setVars = await db.BotState
                 .AsNoTracking()
                 .Where(v => v.Key.StartsWith(SqlConfiguration.ConfigVarPrefix))
@@ -49,7 +49,7 @@ internal static partial class Bot
             Config.InMemorySettings[key] = value;
             Config.RebuildConfiguration();
             key = SqlConfiguration.ConfigVarPrefix + key;
-            await using var db = new BotDb();
+            await using var db = BotDb.OpenRead();
             var stateValue = await db.BotState.FirstOrDefaultAsync(v => v.Key == key).ConfigureAwait(false);
             if (stateValue == null)
             {
@@ -72,7 +72,7 @@ internal static partial class Bot
             Config.InMemorySettings.TryRemove(key, out _);
             Config.RebuildConfiguration();
             key = SqlConfiguration.ConfigVarPrefix + key;
-            await using var db = new BotDb();
+            await using var db = BotDb.OpenRead();
             var stateValue = await db.BotState.Where(v => v.Key == key).FirstOrDefaultAsync().ConfigureAwait(false);
             if (stateValue is not null)
             {

--- a/CompatBot/Commands/Bot.Import.cs
+++ b/CompatBot/Commands/Bot.Import.cs
@@ -17,7 +17,7 @@ internal static partial class Bot
                 try
                 {
                     await CompatList.ImportMetacriticScoresAsync().ConfigureAwait(false);
-                    await using var db = ThumbnailDb.OpenRead();
+                    await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
                     var linkedItems = await db.Thumbnail.CountAsync(i => i.MetacriticId != null).ConfigureAwait(false);
                     await ctx.Channel.SendMessageAsync($"Importing Metacritic info was successful, linked {linkedItems} items").ConfigureAwait(false);
                 }

--- a/CompatBot/Commands/Bot.Import.cs
+++ b/CompatBot/Commands/Bot.Import.cs
@@ -17,7 +17,7 @@ internal static partial class Bot
                 try
                 {
                     await CompatList.ImportMetacriticScoresAsync().ConfigureAwait(false);
-                    await using var db = new ThumbnailDb();
+                    await using var db = ThumbnailDb.OpenRead();
                     var linkedItems = await db.Thumbnail.CountAsync(i => i.MetacriticId != null).ConfigureAwait(false);
                     await ctx.Channel.SendMessageAsync($"Importing Metacritic info was successful, linked {linkedItems} items").ConfigureAwait(false);
                 }

--- a/CompatBot/Commands/Bot.cs
+++ b/CompatBot/Commands/Bot.cs
@@ -89,7 +89,7 @@ internal static partial class Bot
         await using var thumbStream = Config.MemoryStreamManager.GetStream();
         if (name != BackupDbType.Hardware)
         {
-            await using var db = ThumbnailDb.OpenRead();
+            await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
             if (await BackupDbAsync(db, thumbStream, maxSize).ConfigureAwait(false) is { Length: > 0 } error)
                 msg += error + '\n';
             else
@@ -98,7 +98,7 @@ internal static partial class Bot
         await using var hwStream = Config.MemoryStreamManager.GetStream();
         if (name != BackupDbType.Thumbs)
         {
-            await using var db = HardwareDb.OpenRead();
+            await using var db = await HardwareDb.OpenReadAsync().ConfigureAwait(false);
             if (await BackupDbAsync(db, hwStream, maxSize).ConfigureAwait(false) is { Length: > 0 } error)
                 msg += error + '\n';
             else
@@ -146,7 +146,7 @@ internal static partial class Bot
     {
         try
         {
-            await using var db = BotDb.OpenRead();
+            await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
             var status = await db.BotState.FirstOrDefaultAsync(s => s.Key == "bot-status-activity").ConfigureAwait(false);
             var txt = await db.BotState.FirstOrDefaultAsync(s => s.Key == "bot-status-text").ConfigureAwait(false);
             if (message is {Length: >0})
@@ -187,7 +187,7 @@ internal static partial class Bot
         string? dbName = null;
         try
         {
-            await using var botDb = BotDb.OpenRead();
+            await using var botDb = await BotDb.OpenReadAsync().ConfigureAwait(false);
             string dbPath, dbDir;
             await using (var connection = db.Database.GetDbConnection())
             {
@@ -305,7 +305,7 @@ internal static partial class Bot
     internal static void Restart(ulong channelId, string? restartMsg)
     {
         Config.Log.Info($"Saving channelId {channelId} into settings…");
-        using var db = BotDb.OpenRead();
+        using var db = BotDb.OpenWrite();
         var ch = db.BotState.FirstOrDefault(k => k.Key == "bot-restart-channel");
         if (ch is null)
         {

--- a/CompatBot/Commands/Bot.cs
+++ b/CompatBot/Commands/Bot.cs
@@ -89,7 +89,7 @@ internal static partial class Bot
         await using var thumbStream = Config.MemoryStreamManager.GetStream();
         if (name != BackupDbType.Hardware)
         {
-            await using var db = new ThumbnailDb();
+            await using var db = ThumbnailDb.OpenRead();
             if (await BackupDbAsync(db, thumbStream, maxSize).ConfigureAwait(false) is { Length: > 0 } error)
                 msg += error + '\n';
             else
@@ -98,7 +98,7 @@ internal static partial class Bot
         await using var hwStream = Config.MemoryStreamManager.GetStream();
         if (name != BackupDbType.Thumbs)
         {
-            await using var db = new HardwareDb();
+            await using var db = HardwareDb.OpenRead();
             if (await BackupDbAsync(db, hwStream, maxSize).ConfigureAwait(false) is { Length: > 0 } error)
                 msg += error + '\n';
             else
@@ -146,7 +146,7 @@ internal static partial class Bot
     {
         try
         {
-            await using var db = new BotDb();
+            await using var db = BotDb.OpenRead();
             var status = await db.BotState.FirstOrDefaultAsync(s => s.Key == "bot-status-activity").ConfigureAwait(false);
             var txt = await db.BotState.FirstOrDefaultAsync(s => s.Key == "bot-status-text").ConfigureAwait(false);
             if (message is {Length: >0})
@@ -187,7 +187,7 @@ internal static partial class Bot
         string? dbName = null;
         try
         {
-            await using var botDb = new BotDb();
+            await using var botDb = BotDb.OpenRead();
             string dbPath, dbDir;
             await using (var connection = db.Database.GetDbConnection())
             {
@@ -305,7 +305,7 @@ internal static partial class Bot
     internal static void Restart(ulong channelId, string? restartMsg)
     {
         Config.Log.Info($"Saving channelId {channelId} into settings…");
-        using var db = new BotDb();
+        using var db = BotDb.OpenRead();
         var ch = db.BotState.FirstOrDefault(k => k.Key == "bot-restart-channel");
         if (ch is null)
         {

--- a/CompatBot/Commands/BotStatus.cs
+++ b/CompatBot/Commands/BotStatus.cs
@@ -82,7 +82,7 @@ internal static class BotStatus
     {
         try
         {
-            using var db = new BotDb();
+            using var db = BotDb.OpenRead();
             var timestamps = db.Warning
                 .Where(w => w.Timestamp.HasValue && !w.Retracted)
                 .OrderBy(w => w.Timestamp)
@@ -220,7 +220,7 @@ internal static class BotStatus
     {
         try
         {
-            using var db = new ThumbnailDb();
+            using var db = ThumbnailDb.OpenRead();
             var syscallCount = db.SyscallInfo.AsNoTracking().Where(sci => sci.Function.StartsWith("sys_") || sci.Function.StartsWith("_sys_")).Distinct().Count();
             var totalFuncCount = db.SyscallInfo.AsNoTracking().Select(sci => sci.Function).Distinct().Count();
             var fwCallCount = totalFuncCount - syscallCount;
@@ -241,7 +241,7 @@ internal static class BotStatus
     {
         try
         {
-            using var db = new HardwareDb();
+            using var db = HardwareDb.OpenRead();
             var monthAgo = DateTime.UtcNow.AddDays(-30).Ticks;
             var monthCount = db.HwInfo.Count(i => i.Timestamp > monthAgo);
             if (monthCount == 0)
@@ -272,7 +272,7 @@ internal static class BotStatus
     {
         try
         {
-            using var db = new BotDb();
+            using var db = BotDb.OpenRead();
             var kots = db.Kot.Count();
             var doggos = db.Doggo.Count();
             if (kots == 0 && doggos == 0)

--- a/CompatBot/Commands/BotStatus.cs
+++ b/CompatBot/Commands/BotStatus.cs
@@ -56,13 +56,13 @@ internal static class BotStatus
                 CPUs: {Environment.ProcessorCount}
                 Time zones: {TimeParser.TimeZoneMap.Count} out of {TimeParser.TimeZoneAcronyms.Count} resolved, {TimeZoneInfo.GetSystemTimeZones().Count} total
                 """, true);
-        AppendPiracyStats(embed);
+        await AppendPiracyStatsAsync(embed).ConfigureAwait(false);
         AppendCmdStats(embed);
         AppendExplainStats(embed);
         AppendGameLookupStats(embed);
-        AppendSyscallsStats(embed);
-        AppendHwInfoStats(embed);
-        AppendPawStats(embed);
+        await AppendSyscallsStatsAsync(embed).ConfigureAwait(false);
+        await AppendHwInfoStatsAsync(embed).ConfigureAwait(false);
+        await AppendPawStatsAsync(embed).ConfigureAwait(false);
 #if DEBUG
         embed.WithFooter("Test Instance");
 #endif
@@ -78,16 +78,16 @@ internal static class BotStatus
             {(string.IsNullOrEmpty(Config.GithubToken) ? "❌" : "✅")} GitHub
             """;
 
-    private static void AppendPiracyStats(DiscordEmbedBuilder embed)
+    private static async ValueTask AppendPiracyStatsAsync(DiscordEmbedBuilder embed)
     {
         try
         {
-            using var db = BotDb.OpenRead();
-            var timestamps = db.Warning
+            await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
+            var timestamps = await db.Warning
                 .Where(w => w.Timestamp.HasValue && !w.Retracted)
                 .OrderBy(w => w.Timestamp)
                 .Select(w => w.Timestamp!.Value)
-                .ToList();
+                .ToListAsync();
             var firstWarnTimestamp = timestamps.FirstOrDefault();
             var previousTimestamp = firstWarnTimestamp;
             var longestGapBetweenWarning = 0L;
@@ -216,11 +216,11 @@ internal static class BotStatus
         embed.AddField($"Top {top.Count} Recent Game Lookups", statsBuilder.ToString().TrimEnd(), true);
     }
 
-    private static void AppendSyscallsStats(DiscordEmbedBuilder embed)
+    private static async ValueTask AppendSyscallsStatsAsync(DiscordEmbedBuilder embed)
     {
         try
         {
-            using var db = ThumbnailDb.OpenRead();
+            await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
             var syscallCount = db.SyscallInfo.AsNoTracking().Where(sci => sci.Function.StartsWith("sys_") || sci.Function.StartsWith("_sys_")).Distinct().Count();
             var totalFuncCount = db.SyscallInfo.AsNoTracking().Select(sci => sci.Function).Distinct().Count();
             var fwCallCount = totalFuncCount - syscallCount;
@@ -229,7 +229,9 @@ internal static class BotStatus
                 Tracked game IDs: {gameCount}
                 Tracked syscalls: {syscallCount} function{(syscallCount == 1 ? "" : "s")}
                 Tracked fw calls: {fwCallCount} function{(fwCallCount == 1 ? "" : "s")}
-                """, true);
+                """,
+                true
+            );
         }
         catch (Exception e)
         {
@@ -237,14 +239,14 @@ internal static class BotStatus
         }
     }
 
-    private static void AppendHwInfoStats(DiscordEmbedBuilder embed)
+    private static async ValueTask AppendHwInfoStatsAsync(DiscordEmbedBuilder embed)
     {
         try
         {
-            using var db = HardwareDb.OpenRead();
+            await using var db = await HardwareDb.OpenReadAsync().ConfigureAwait(false);
             var monthAgo = DateTime.UtcNow.AddDays(-30).Ticks;
             var monthCount = db.HwInfo.Count(i => i.Timestamp > monthAgo);
-            if (monthCount == 0)
+            if (monthCount is 0)
                 return;
             
             var totalCount = db.HwInfo.Count();
@@ -257,10 +259,13 @@ internal static class BotStatus
 
             var cpuInfo = cpu is null ? "" : $"Popular CPU: {cpu.maker} {cpu.name} ({cpu.count * 100.0 / monthCount:0.##}%)";
             embed.AddField("Hardware Stats", $"""
-                Total: {totalCount} system{(totalCount == 1 ? "" : "s")}
-                Last 30 days: {monthCount} system{(monthCount == 1 ? "" : "s")}
+                Total: {totalCount} system{(totalCount is 1 ? "" : "s")}
+                Last 30 days: {monthCount} system{(monthCount is 1 ? "" : "s")}
                 {cpuInfo}
-                """.TrimEnd(), true);
+                """.TrimEnd()
+                ,
+                true
+            );
         }
         catch (Exception e)
         {
@@ -268,14 +273,14 @@ internal static class BotStatus
         }
     }
 
-    private static void AppendPawStats(DiscordEmbedBuilder embed)
+    private static async ValueTask AppendPawStatsAsync(DiscordEmbedBuilder embed)
     {
         try
         {
-            using var db = BotDb.OpenRead();
+            await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
             var kots = db.Kot.Count();
             var doggos = db.Doggo.Count();
-            if (kots == 0 && doggos == 0)
+            if (kots is 0 && doggos is 0)
                 return;
 
             var diff = kots > doggos ? (double)kots / doggos - 1.0 : (double)doggos / kots - 1.0;

--- a/CompatBot/Commands/CommandsManagement.cs
+++ b/CompatBot/Commands/CommandsManagement.cs
@@ -67,9 +67,9 @@ internal static class CommandsManagement
             {
                 if (cmd is null)
                     foreach (var c in ctx.Extension.Commands.Values)
-                        DisableSubcommands(ctx, c);
+                        await DisableSubcommandsAsync(ctx, c).ConfigureAwait(false);
                 else
-                    DisableSubcommands(ctx, cmd);
+                    await DisableSubcommandsAsync(ctx, cmd).ConfigureAwait(false);
                 if (ctx.Command.Parent is Command parent && parent.FullName.StartsWith(command))
                     await ctx.RespondAsync("Some subcommands cannot be disabled", ephemeral: true).ConfigureAwait(false);
                 else
@@ -90,7 +90,7 @@ internal static class CommandsManagement
             }
 
             command = cmd.FullName;
-            DisabledCommandsProvider.Disable(command);
+            await DisabledCommandsProvider.DisableAsync(command).ConfigureAwait(false);
             await ctx.RespondAsync($"{Config.Reactions.Success} Disabled `{command}`", ephemeral: true).ConfigureAwait(false);
         }
     }
@@ -106,7 +106,7 @@ internal static class CommandsManagement
         await ctx.DeferResponseAsync(true).ConfigureAwait(false);
         if (command is "*")
         {
-            DisabledCommandsProvider.Clear();
+            await DisabledCommandsProvider.ClearAsync().ConfigureAwait(false);
             await ctx.RespondAsync($"{Config.Reactions.Success} Enabled all the commands", ephemeral: true).ConfigureAwait(false);
             return;
         }
@@ -127,7 +127,7 @@ internal static class CommandsManagement
 
             try
             {
-                EnableSubcommands(ctx, cmd);
+                await EnableSubcommandsAsync(ctx, cmd).ConfigureAwait(false);
                 await ctx.RespondAsync($"{Config.Reactions.Success} Enabled `{command}` and all subcommands", ephemeral: true).ConfigureAwait(false);
             }
             catch (Exception e)
@@ -145,7 +145,7 @@ internal static class CommandsManagement
             }
 
             command = cmd.FullName;
-            DisabledCommandsProvider.Enable(command);
+            await DisabledCommandsProvider.EnableAsync(command).ConfigureAwait(false);
             await ctx.RespondAsync($"{Config.Reactions.Success} Enabled `{command}`", ephemeral: true).ConfigureAwait(false);
         }
     }
@@ -173,25 +173,25 @@ internal static class CommandsManagement
         return result;
     }
 
-    private static void DisableSubcommands(CommandContext ctx, Command cmd)
+    private static async ValueTask DisableSubcommandsAsync(CommandContext ctx, Command cmd)
     {
         if (ctx.Command.Parent is not Command p || cmd.FullName.StartsWith(p.FullName))
             return;
 
-        DisabledCommandsProvider.Disable(cmd.FullName);
+        await DisabledCommandsProvider.DisableAsync(cmd.FullName).ConfigureAwait(false);
         if (cmd is Command group)
             foreach (var subCmd in group.Subcommands)
-                DisableSubcommands(ctx, subCmd);
+                await DisableSubcommandsAsync(ctx, subCmd).ConfigureAwait(false);
     }
 
-    private static void EnableSubcommands(CommandContext ctx, Command cmd)
+    private static async ValueTask EnableSubcommandsAsync(CommandContext ctx, Command cmd)
     {
         if (ctx.Command.Parent is not Command p || cmd.FullName.StartsWith(p.FullName))
             return;
 
-        DisabledCommandsProvider.Enable(cmd.FullName);
+        await DisabledCommandsProvider.EnableAsync(cmd.FullName).ConfigureAwait(false);
         if (cmd is Command group)
             foreach (var subCmd in group.Subcommands)
-                EnableSubcommands(ctx, subCmd);
+                await EnableSubcommandsAsync(ctx, subCmd).ConfigureAwait(false);
     }
 }

--- a/CompatBot/Commands/CompatList.Latest.cs
+++ b/CompatBot/Commands/CompatList.Latest.cs
@@ -155,7 +155,7 @@ internal static partial class CompatList
                 await compatChannel.SendMessageAsync(embed: embed.Build()).ConfigureAwait(false);
                 lastUpdateInfo = latestUpdatePr;
                 lastFullBuildNumber = latestUpdateBuild;
-                await using var db = new BotDb();
+                await using var db = BotDb.OpenRead();
                 var currentState = await db.BotState.FirstOrDefaultAsync(k => k.Key == Rpcs3UpdateStateKey).ConfigureAwait(false);
                 if (currentState == null)
                     await db.BotState.AddAsync(new() {Key = Rpcs3UpdateStateKey, Value = latestUpdatePr}).ConfigureAwait(false);

--- a/CompatBot/Commands/CompatList.Latest.cs
+++ b/CompatBot/Commands/CompatList.Latest.cs
@@ -155,7 +155,7 @@ internal static partial class CompatList
                 await compatChannel.SendMessageAsync(embed: embed.Build()).ConfigureAwait(false);
                 lastUpdateInfo = latestUpdatePr;
                 lastFullBuildNumber = latestUpdateBuild;
-                await using var db = BotDb.OpenRead();
+                await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
                 var currentState = await db.BotState.FirstOrDefaultAsync(k => k.Key == Rpcs3UpdateStateKey).ConfigureAwait(false);
                 if (currentState == null)
                     await db.BotState.AddAsync(new() {Key = Rpcs3UpdateStateKey, Value = latestUpdatePr}).ConfigureAwait(false);

--- a/CompatBot/Commands/CompatList.Top.cs
+++ b/CompatBot/Commands/CompatList.Top.cs
@@ -28,7 +28,7 @@ internal static partial class CompatList
             if (!Enum.TryParse(status, true, out CompatStatus s))
                 s = CompatStatus.Playable;
 
-            await using var db = new ThumbnailDb();
+            await using var db = ThumbnailDb.OpenRead();
             var queryBase = db.Thumbnail.AsNoTracking();
             if (exactStatus)
                 queryBase = queryBase.Where(g => g.CompatibilityStatus == s);

--- a/CompatBot/Commands/CompatList.Top.cs
+++ b/CompatBot/Commands/CompatList.Top.cs
@@ -28,7 +28,7 @@ internal static partial class CompatList
             if (!Enum.TryParse(status, true, out CompatStatus s))
                 s = CompatStatus.Playable;
 
-            await using var db = ThumbnailDb.OpenRead();
+            await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
             var queryBase = db.Thumbnail.AsNoTracking();
             if (exactStatus)
                 queryBase = queryBase.Where(g => g.CompatibilityStatus == s);

--- a/CompatBot/Commands/CompatList.cs
+++ b/CompatBot/Commands/CompatList.cs
@@ -33,7 +33,7 @@ internal static partial class CompatList
 
     static CompatList()
     {
-        using var db = new BotDb();
+        using var db = BotDb.OpenRead();
         lastUpdateInfo = db.BotState.FirstOrDefault(k => k.Key == Rpcs3UpdateStateKey)?.Value;
         lastFullBuildNumber = db.BotState.FirstOrDefault(k => k.Key == Rpcs3UpdateBuildKey)?.Value;
         //lastUpdateInfo = "8022";
@@ -133,7 +133,7 @@ internal static partial class CompatList
     {
         var timer = Stopwatch.StartNew();
         var title = requestBuilder.Search;
-        using var db = new ThumbnailDb();
+        using var db = ThumbnailDb.OpenRead();
         var matches = db.Thumbnail
             .AsNoTracking()
             .AsEnumerable()
@@ -227,7 +227,7 @@ internal static partial class CompatList
         if (list is null)
             return;
             
-        await using var db = new ThumbnailDb();
+        await using var db = ThumbnailDb.OpenRead();
         foreach (var kvp in list.Results)
         {
             var (productCode, info) = kvp;
@@ -306,7 +306,7 @@ internal static partial class CompatList
                 .Select(i => i.WithTitle(i.Title.Replace("HAWX", "H.A.W.X")))
         );
 
-        await using var db = new ThumbnailDb();
+        await using var db = ThumbnailDb.OpenRead();
         foreach (var mcScore in scoreList.Where(s => s.CriticScore > 0 || s.UserScore > 0))
         {
             if (Config.Cts.IsCancellationRequested)

--- a/CompatBot/Commands/ContentFilters.cs
+++ b/CompatBot/Commands/ContentFilters.cs
@@ -37,7 +37,7 @@ internal sealed partial class ContentFilters
             new AsciiColumn("Actions"),
             new AsciiColumn("Custom message", maxWidth: 2048)
         );
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         var duplicates = new Dictionary<string, FilterContext>(StringComparer.InvariantCultureIgnoreCase);
         var filters = db.Piracystring.Where(ps => !ps.Disabled).AsNoTracking().AsEnumerable().OrderBy(ps => ps.String.ToUpperInvariant()).ToList();
         var nonUniqueTriggers = (
@@ -130,7 +130,7 @@ internal sealed partial class ContentFilters
         }
 
         explanation = explanation?.ToLowerInvariant();
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         if (explanation is {Length: >0} && !await db.Explanation.AnyAsync(e => e.Keyword == explanation).ConfigureAwait(false))
         {
             await ctx.RespondAsync($"❌ Unknown explanation term: {explanation}", ephemeral: ephemeral).ConfigureAwait(false);
@@ -235,7 +235,7 @@ internal sealed partial class ContentFilters
                     return;
                 }
 
-                await using var db = new BotDb();
+                await using var db = BotDb.OpenRead();
                 foreach (var element in xml.Root.Elements("game"))
                 {
                     var name = element.Element("rom")?.Attribute("name")?.Value;
@@ -312,7 +312,7 @@ internal sealed partial class ContentFilters
             }
         }
 
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         explanation = explanation?.ToLowerInvariant();
         if (explanation is {Length: >0} && !await db.Explanation.AnyAsync(e => e.Keyword == explanation).ConfigureAwait(false))
         {
@@ -367,7 +367,7 @@ internal sealed partial class ContentFilters
     )
     {
         var ephemeral = !ctx.Channel.IsPrivate;
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         var filter = await db.Piracystring.FirstOrDefaultAsync(ps => ps.Id == id && !ps.Disabled).ConfigureAwait(false);
         if (filter is null)
         {
@@ -391,7 +391,7 @@ internal sealed partial class ContentFilters
         var ephemeral = !ctx.Channel.IsPrivate;
         int removedFilters;
         var removedTriggers = new StringBuilder();
-        await using (var db = new BotDb())
+        await using (var db = BotDb.OpenRead())
         {
             foreach (var f in db.Piracystring.Where(ps => ps.Id == id && !ps.Disabled))
             {

--- a/CompatBot/Commands/ContentFilters.cs
+++ b/CompatBot/Commands/ContentFilters.cs
@@ -37,7 +37,7 @@ internal sealed partial class ContentFilters
             new AsciiColumn("Actions"),
             new AsciiColumn("Custom message", maxWidth: 2048)
         );
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         var duplicates = new Dictionary<string, FilterContext>(StringComparer.InvariantCultureIgnoreCase);
         var filters = db.Piracystring.Where(ps => !ps.Disabled).AsNoTracking().AsEnumerable().OrderBy(ps => ps.String.ToUpperInvariant()).ToList();
         var nonUniqueTriggers = (
@@ -130,7 +130,7 @@ internal sealed partial class ContentFilters
         }
 
         explanation = explanation?.ToLowerInvariant();
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         if (explanation is {Length: >0} && !await db.Explanation.AnyAsync(e => e.Keyword == explanation).ConfigureAwait(false))
         {
             await ctx.RespondAsync($"❌ Unknown explanation term: {explanation}", ephemeral: ephemeral).ConfigureAwait(false);
@@ -235,7 +235,7 @@ internal sealed partial class ContentFilters
                     return;
                 }
 
-                await using var db = BotDb.OpenRead();
+                await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
                 foreach (var element in xml.Root.Elements("game"))
                 {
                     var name = element.Element("rom")?.Attribute("name")?.Value;
@@ -312,7 +312,7 @@ internal sealed partial class ContentFilters
             }
         }
 
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         explanation = explanation?.ToLowerInvariant();
         if (explanation is {Length: >0} && !await db.Explanation.AnyAsync(e => e.Keyword == explanation).ConfigureAwait(false))
         {
@@ -367,7 +367,7 @@ internal sealed partial class ContentFilters
     )
     {
         var ephemeral = !ctx.Channel.IsPrivate;
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         var filter = await db.Piracystring.FirstOrDefaultAsync(ps => ps.Id == id && !ps.Disabled).ConfigureAwait(false);
         if (filter is null)
         {
@@ -391,7 +391,7 @@ internal sealed partial class ContentFilters
         var ephemeral = !ctx.Channel.IsPrivate;
         int removedFilters;
         var removedTriggers = new StringBuilder();
-        await using (var db = BotDb.OpenRead())
+        await using (var db = await BotDb.OpenReadAsync().ConfigureAwait(false))
         {
             foreach (var f in db.Piracystring.Where(ps => ps.Id == id && !ps.Disabled))
             {

--- a/CompatBot/Commands/Events.cs
+++ b/CompatBot/Commands/Events.cs
@@ -383,14 +383,14 @@ internal static partial class Events
         return name;
     }
 
-    private static async Task<string?> FuzzyMatchEventName(BotDb db, string? eventName)
+    private static async ValueTask<string?> FuzzyMatchEventName(BotDb db, string? eventName)
     {
         var knownEventNames = await db.EventSchedule.Select(e => e.EventName).Distinct().ToListAsync().ConfigureAwait(false);
         var (score, name) = knownEventNames.Select(n => (score: eventName.GetFuzzyCoefficientCached(n), name: n)).OrderByDescending(t => t.score).FirstOrDefault();
         return score > 0.8 ? name : eventName;
     }
 
-    private static async Task<string?> FuzzyMatchEntryName(BotDb db, string? eventName)
+    private static async ValueTask<string?> FuzzyMatchEntryName(BotDb db, string? eventName)
     {
         var now = DateTime.UtcNow.Ticks;
         var knownNames = await db.EventSchedule.Where(e => e.End > now).Select(e => e.Name).ToListAsync().ConfigureAwait(false);

--- a/CompatBot/Commands/Events.cs
+++ b/CompatBot/Commands/Events.cs
@@ -30,7 +30,7 @@ internal static partial class Events
         var current = DateTime.UtcNow;
 #endif
         var currentTicks = current.Ticks;
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         var currentEvents = await db.EventSchedule.OrderBy(e => e.End).Where(e => e.Start <= currentTicks && e.End >= currentTicks).ToListAsync().ConfigureAwait(false);
         var nextEvent = await db.EventSchedule.OrderBy(e => e.Start).FirstOrDefaultAsync(e => e.Start > currentTicks).ConfigureAwait(false);
         if (string.IsNullOrEmpty(name))
@@ -203,7 +203,7 @@ internal static partial class Events
         evt.Name = name;
         evt.EventName = string.IsNullOrWhiteSpace(@event) || @event == "-" ? null : @event;
         evt.Year = newTime.Year;
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         await db.EventSchedule.AddAsync(evt).ConfigureAwait(false);
         await db.SaveChangesAsync().ConfigureAwait(false);
         await ctx.RespondAsync(embed: FormatEvent(evt).WithTitle("Created new event schedule entry #" + evt.Id), ephemeral: ephemeral).ConfigureAwait(false);
@@ -218,7 +218,7 @@ internal static partial class Events
     )
     {
         var ephemeral = !ctx.Channel.IsSpamChannel();
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         var eventsToRemove = await db.EventSchedule.Where(evt => evt.Id == id).ToListAsync().ConfigureAwait(false);
         db.EventSchedule.RemoveRange(eventsToRemove);
         var removedCount = await db.SaveChangesAsync().ConfigureAwait(false);
@@ -234,7 +234,7 @@ internal static partial class Events
     public Task ClearGeneric(CommandContext ctx, [Description("Optional year to remove, by default everything before current year")] int? year = null)
     {
         var currentYear = DateTime.UtcNow.Year;
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         var itemsToRemove = await db.EventSchedule.Where(e =>
             year.HasValue
                 ? e.Year == year
@@ -262,7 +262,7 @@ internal static partial class Events
     )
     {
         var ephemeral = !ctx.Channel.IsSpamChannel();
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         var evt = db.EventSchedule.FirstOrDefault(e => e.Id == id);
         if (evt is null)
         {
@@ -312,7 +312,7 @@ internal static partial class Events
         var ephemeral = !ctx.Channel.IsSpamChannel() || ModProvider.IsMod(ctx.User.Id);
         var showAll = "all".Equals(@event, StringComparison.InvariantCultureIgnoreCase);
         var currentTicks = DateTime.UtcNow.Ticks;
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         IQueryable<EventSchedule> query = db.EventSchedule;
         if (year.HasValue)
             query = query.Where(e => e.Year == year);

--- a/CompatBot/Commands/Explain.cs
+++ b/CompatBot/Commands/Explain.cs
@@ -149,7 +149,7 @@ internal static class Explain
 
             var response = new DiscordInteractionResponseBuilder().AsEphemeral();
             await interaction.CreateResponseAsync(DiscordInteractionResponseType.DeferredChannelMessageWithSource, response).ConfigureAwait(false);
-            await using var db = BotDb.OpenRead();
+            await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
             if (await db.Explanation.AnyAsync(e => e.Keyword == term).ConfigureAwait(false))
             {
                 await interaction.EditOriginalResponseAsync(
@@ -224,7 +224,7 @@ internal static class Explain
             }
         }
         
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         var item = await db.Explanation.FirstOrDefaultAsync(e => e.Keyword == term).ConfigureAwait(false);
         if (item is null)
         {
@@ -298,7 +298,7 @@ internal static class Explain
     )
     {
         term = term.ToLowerInvariant().StripQuotes();
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         var item = await db.Explanation.FirstOrDefaultAsync(e => e.Keyword == term).ConfigureAwait(false);
         if (item is null)
         {
@@ -335,7 +335,7 @@ internal static class Explain
     {
         var ephemeral = !ctx.Channel.IsSpamChannel();
         await ctx.DeferResponseAsync(ephemeral).ConfigureAwait(false);
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         var allTerms = await db.Explanation.AsNoTracking().Select(e => e.Keyword).ToListAsync();
         await using var stream = Config.MemoryStreamManager.GetStream();
         await using var writer = new StreamWriter(stream);
@@ -357,7 +357,7 @@ internal static class Explain
         string term
     )
     {
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         var item = await db.Explanation.FirstOrDefaultAsync(e => e.Keyword == term).ConfigureAwait(false);
         if (item is null)
         {
@@ -435,7 +435,7 @@ internal static class Explain
     
     internal static async ValueTask<(Explanation? explanation, string? fuzzyMatch, double score)> LookupTerm(string term)
     {
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         string? fuzzyMatch = null;
         double coefficient;
         var explanation = await db.Explanation.FirstOrDefaultAsync(e => e.Keyword == term).ConfigureAwait(false);

--- a/CompatBot/Commands/Explain.cs
+++ b/CompatBot/Commands/Explain.cs
@@ -149,7 +149,7 @@ internal static class Explain
 
             var response = new DiscordInteractionResponseBuilder().AsEphemeral();
             await interaction.CreateResponseAsync(DiscordInteractionResponseType.DeferredChannelMessageWithSource, response).ConfigureAwait(false);
-            await using var db = new BotDb();
+            await using var db = BotDb.OpenRead();
             if (await db.Explanation.AnyAsync(e => e.Keyword == term).ConfigureAwait(false))
             {
                 await interaction.EditOriginalResponseAsync(
@@ -224,7 +224,7 @@ internal static class Explain
             }
         }
         
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         var item = await db.Explanation.FirstOrDefaultAsync(e => e.Keyword == term).ConfigureAwait(false);
         if (item is null)
         {
@@ -298,7 +298,7 @@ internal static class Explain
     )
     {
         term = term.ToLowerInvariant().StripQuotes();
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         var item = await db.Explanation.FirstOrDefaultAsync(e => e.Keyword == term).ConfigureAwait(false);
         if (item is null)
         {
@@ -335,7 +335,7 @@ internal static class Explain
     {
         var ephemeral = !ctx.Channel.IsSpamChannel();
         await ctx.DeferResponseAsync(ephemeral).ConfigureAwait(false);
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         var allTerms = await db.Explanation.AsNoTracking().Select(e => e.Keyword).ToListAsync();
         await using var stream = Config.MemoryStreamManager.GetStream();
         await using var writer = new StreamWriter(stream);
@@ -357,7 +357,7 @@ internal static class Explain
         string term
     )
     {
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         var item = await db.Explanation.FirstOrDefaultAsync(e => e.Keyword == term).ConfigureAwait(false);
         if (item is null)
         {
@@ -435,7 +435,7 @@ internal static class Explain
     
     internal static async ValueTask<(Explanation? explanation, string? fuzzyMatch, double score)> LookupTerm(string term)
     {
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         string? fuzzyMatch = null;
         double coefficient;
         var explanation = await db.Explanation.FirstOrDefaultAsync(e => e.Keyword == term).ConfigureAwait(false);

--- a/CompatBot/Commands/ForcedNicknames.cs
+++ b/CompatBot/Commands/ForcedNicknames.cs
@@ -72,7 +72,7 @@ internal static class ForcedNicknames
                 guilds = [ctx.Guild];
 
             int changed = 0, noPermissions = 0, failed = 0;
-            await using var db = new BotDb();
+            await using var db = BotDb.OpenRead();
             foreach (var guild in guilds)
             {
                 if (!discordUser.IsBotSafeCheck())
@@ -157,7 +157,7 @@ internal static class ForcedNicknames
                 return;
             }
 
-            await using var db = new BotDb();
+            await using var db = BotDb.OpenRead();
             var enforcedRules = ctx.Guild is null
                 ? await db.ForcedNicknames.Where(mem => mem.UserId == discordUser.Id).ToListAsync().ConfigureAwait(false)
                 : await db.ForcedNicknames.Where(mem => mem.UserId == discordUser.Id && mem.GuildId == ctx.Guild.Id).ToListAsync().ConfigureAwait(false);
@@ -256,7 +256,7 @@ internal static class ForcedNicknames
     [Description("Lists all users who has restricted nickname.")]
     public async Task List(CommandContext ctx)
     {
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         var selectExpr = db.ForcedNicknames.AsNoTracking();
         if (ctx.Guild != null)
             selectExpr = selectExpr.Where(mem => mem.GuildId == ctx.Guild.Id);

--- a/CompatBot/Commands/ForcedNicknames.cs
+++ b/CompatBot/Commands/ForcedNicknames.cs
@@ -25,7 +25,7 @@ internal static class ForcedNicknames
         }
 
         var interaction = ctx.Interaction;
-        var suggestedName = UsernameZalgoMonitor.GenerateRandomName(discordUser.Id);
+        var suggestedName = await UsernameZalgoMonitor.GenerateRandomNameAsync(discordUser.Id).ConfigureAwait(false);
         var modal = new DiscordInteractionResponseBuilder()
             .AsEphemeral()
             .WithCustomId($"modal:nickname:{Guid.NewGuid():n}")
@@ -72,7 +72,7 @@ internal static class ForcedNicknames
                 guilds = [ctx.Guild];
 
             int changed = 0, noPermissions = 0, failed = 0;
-            await using var db = BotDb.OpenRead();
+            await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
             foreach (var guild in guilds)
             {
                 if (!discordUser.IsBotSafeCheck())
@@ -157,7 +157,7 @@ internal static class ForcedNicknames
                 return;
             }
 
-            await using var db = BotDb.OpenRead();
+            await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
             var enforcedRules = ctx.Guild is null
                 ? await db.ForcedNicknames.Where(mem => mem.UserId == discordUser.Id).ToListAsync().ConfigureAwait(false)
                 : await db.ForcedNicknames.Where(mem => mem.UserId == discordUser.Id && mem.GuildId == ctx.Guild.Id).ToListAsync().ConfigureAwait(false);
@@ -233,7 +233,7 @@ internal static class ForcedNicknames
     [Description("Set automatically generated nickname without enforcing it")]
     public static async ValueTask Autorename(UserCommandContext ctx, DiscordUser discordUser)
     {
-        var newName = UsernameZalgoMonitor.GenerateRandomName(discordUser.Id);
+        var newName = await UsernameZalgoMonitor.GenerateRandomNameAsync(discordUser.Id).ConfigureAwait(false);
         try
         {
             if (await ctx.Client.GetMemberAsync(discordUser).ConfigureAwait(false) is { } member)
@@ -256,7 +256,7 @@ internal static class ForcedNicknames
     [Description("Lists all users who has restricted nickname.")]
     public async Task List(CommandContext ctx)
     {
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         var selectExpr = db.ForcedNicknames.AsNoTracking();
         if (ctx.Guild != null)
             selectExpr = selectExpr.Where(mem => mem.GuildId == ctx.Guild.Id);

--- a/CompatBot/Commands/Fortune.cs
+++ b/CompatBot/Commands/Fortune.cs
@@ -50,7 +50,7 @@ internal static class Fortune
 
             await ctx.RespondAsync("Importing…", ephemeral: true).ConfigureAwait(false);
             var stopwatch = Stopwatch.StartNew();
-            await using var db = ThumbnailDb.OpenRead();
+            await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
             using var httpClient = HttpClientFactory.Create(new CompressionMessageHandler());
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
             var response = await httpClient.SendAsync(request, cts.Token).ConfigureAwait(false);
@@ -149,7 +149,7 @@ internal static class Fortune
             var count = 0;
             await using var outputStream = Config.MemoryStreamManager.GetStream();
             await using var writer = new StreamWriter(outputStream);
-            await using var db = ThumbnailDb.OpenRead();
+            await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
             foreach (var fortune in db.Fortune.AsNoTracking())
             {
                 if (Config.Cts.Token.IsCancellationRequested)
@@ -184,7 +184,7 @@ internal static class Fortune
         }
 
         await ctx.DeferResponseAsync(true).ConfigureAwait(false);
-        await using var db = ThumbnailDb.OpenRead();
+        await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
         db.Fortune.RemoveRange(db.Fortune);
         var count = await db.SaveChangesAsync(Config.Cts.Token).ConfigureAwait(false);
         await ctx.RespondAsync($"{Config.Reactions.Success} Removed {count} fortune{(count == 1 ? "" : "s")}", ephemeral: true).ConfigureAwait(false);
@@ -194,7 +194,7 @@ internal static class Fortune
     {
         var prefix = DateTime.UtcNow.ToString("yyyyMMdd")+ user.Id.ToString("x16");
         var rng = new Random(prefix.GetStableHash());
-        await using var db = ThumbnailDb.OpenRead();
+        await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
         Database.Fortune? fortune;
         do
         {

--- a/CompatBot/Commands/Fortune.cs
+++ b/CompatBot/Commands/Fortune.cs
@@ -50,7 +50,7 @@ internal static class Fortune
 
             await ctx.RespondAsync("Importing…", ephemeral: true).ConfigureAwait(false);
             var stopwatch = Stopwatch.StartNew();
-            await using var db = new ThumbnailDb();
+            await using var db = ThumbnailDb.OpenRead();
             using var httpClient = HttpClientFactory.Create(new CompressionMessageHandler());
             using var request = new HttpRequestMessage(HttpMethod.Get, url);
             var response = await httpClient.SendAsync(request, cts.Token).ConfigureAwait(false);
@@ -149,7 +149,7 @@ internal static class Fortune
             var count = 0;
             await using var outputStream = Config.MemoryStreamManager.GetStream();
             await using var writer = new StreamWriter(outputStream);
-            await using var db = new ThumbnailDb();
+            await using var db = ThumbnailDb.OpenRead();
             foreach (var fortune in db.Fortune.AsNoTracking())
             {
                 if (Config.Cts.Token.IsCancellationRequested)
@@ -184,7 +184,7 @@ internal static class Fortune
         }
 
         await ctx.DeferResponseAsync(true).ConfigureAwait(false);
-        await using var db = new ThumbnailDb();
+        await using var db = ThumbnailDb.OpenRead();
         db.Fortune.RemoveRange(db.Fortune);
         var count = await db.SaveChangesAsync(Config.Cts.Token).ConfigureAwait(false);
         await ctx.RespondAsync($"{Config.Reactions.Success} Removed {count} fortune{(count == 1 ? "" : "s")}", ephemeral: true).ConfigureAwait(false);
@@ -194,7 +194,7 @@ internal static class Fortune
     {
         var prefix = DateTime.UtcNow.ToString("yyyyMMdd")+ user.Id.ToString("x16");
         var rng = new Random(prefix.GetStableHash());
-        await using var db = new ThumbnailDb();
+        await using var db = ThumbnailDb.OpenRead();
         Database.Fortune? fortune;
         do
         {

--- a/CompatBot/Commands/Hardware.cs
+++ b/CompatBot/Commands/Hardware.cs
@@ -17,7 +17,7 @@ internal static class Hardware
         var maxDays = DateTime.UtcNow - new DateTime(2011, 5, 23, 0, 0, 0, DateTimeKind.Utc);
         period = Math.Clamp(Math.Abs(period), 1, (int)maxDays.TotalDays);
         var ts = DateTime.UtcNow.AddDays(-period).Ticks;
-        await using var db = HardwareDb.OpenRead();
+        await using var db = await HardwareDb.OpenReadAsync().ConfigureAwait(false);
         var count = await db.HwInfo.AsNoTracking().CountAsync(i => i.Timestamp > ts).ConfigureAwait(false);
         if (count is 0)
         {

--- a/CompatBot/Commands/Hardware.cs
+++ b/CompatBot/Commands/Hardware.cs
@@ -17,7 +17,7 @@ internal static class Hardware
         var maxDays = DateTime.UtcNow - new DateTime(2011, 5, 23, 0, 0, 0, DateTimeKind.Utc);
         period = Math.Clamp(Math.Abs(period), 1, (int)maxDays.TotalDays);
         var ts = DateTime.UtcNow.AddDays(-period).Ticks;
-        await using var db = new HardwareDb();
+        await using var db = HardwareDb.OpenRead();
         var count = await db.HwInfo.AsNoTracking().CountAsync(i => i.Timestamp > ts).ConfigureAwait(false);
         if (count is 0)
         {

--- a/CompatBot/Commands/Invites.cs
+++ b/CompatBot/Commands/Invites.cs
@@ -16,7 +16,7 @@ internal static class Invites
     public static async ValueTask List(SlashCommandContext ctx)
     {
         const string linkPrefix = "discord.gg/";
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         var whitelistedInvites = await db.WhitelistedInvites.ToListAsync().ConfigureAwait(false);
         if (whitelistedInvites.Count is 0)
         {
@@ -144,7 +144,7 @@ internal static class Invites
         [Description("Custom server name"), MinMaxLength(3)] string name
     )
     {
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         var invite = await db.WhitelistedInvites.FirstOrDefaultAsync(i => i.Id == id).ConfigureAwait(false);
         if (invite is null)
         {

--- a/CompatBot/Commands/Invites.cs
+++ b/CompatBot/Commands/Invites.cs
@@ -16,7 +16,7 @@ internal static class Invites
     public static async ValueTask List(SlashCommandContext ctx)
     {
         const string linkPrefix = "discord.gg/";
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         var whitelistedInvites = await db.WhitelistedInvites.ToListAsync().ConfigureAwait(false);
         if (whitelistedInvites.Count is 0)
         {
@@ -144,7 +144,7 @@ internal static class Invites
         [Description("Custom server name"), MinMaxLength(3)] string name
     )
     {
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         var invite = await db.WhitelistedInvites.FirstOrDefaultAsync(i => i.Id == id).ConfigureAwait(false);
         if (invite is null)
         {

--- a/CompatBot/Commands/Misc.cs
+++ b/CompatBot/Commands/Misc.cs
@@ -242,7 +242,7 @@ internal static partial class Misc
         public static async ValueTask Game(SlashCommandContext ctx)
         {
             var ephemeral = !ctx.Channel.IsSpamChannel();
-            var db = new ThumbnailDb();
+            var db = ThumbnailDb.OpenRead();
             await using var _ = db.ConfigureAwait(false);
             var count = await db.Thumbnail.CountAsync().ConfigureAwait(false);
             if (count is 0)

--- a/CompatBot/Commands/Misc.cs
+++ b/CompatBot/Commands/Misc.cs
@@ -242,7 +242,7 @@ internal static partial class Misc
         public static async ValueTask Game(SlashCommandContext ctx)
         {
             var ephemeral = !ctx.Channel.IsSpamChannel();
-            var db = ThumbnailDb.OpenRead();
+            var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
             await using var _ = db.ConfigureAwait(false);
             var count = await db.Thumbnail.CountAsync().ConfigureAwait(false);
             if (count is 0)

--- a/CompatBot/Commands/Psn.Check.cs
+++ b/CompatBot/Commands/Psn.Check.cs
@@ -80,7 +80,7 @@ internal static partial class Psn
                 return;
 
             var newVersion = fwList[0].Version;
-            await using var db = BotDb.OpenRead();
+            await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
             var fwVersionState = db.BotState.FirstOrDefault(s => s.Key == "Latest-Firmware-Version");
             latestFwVersion ??= fwVersionState?.Value;
             if (latestFwVersion is null

--- a/CompatBot/Commands/Psn.Check.cs
+++ b/CompatBot/Commands/Psn.Check.cs
@@ -80,7 +80,7 @@ internal static partial class Psn
                 return;
 
             var newVersion = fwList[0].Version;
-            await using var db = new BotDb();
+            await using var db = BotDb.OpenRead();
             var fwVersionState = db.BotState.FirstOrDefault(s => s.Key == "Latest-Firmware-Version");
             latestFwVersion ??= fwVersionState?.Value;
             if (latestFwVersion is null

--- a/CompatBot/Commands/Psn.cs
+++ b/CompatBot/Commands/Psn.cs
@@ -25,7 +25,7 @@ internal static partial class Psn
     {
         var ephemeral = !ctx.Channel.IsSpamChannel();
         productCode = productCode.ToUpperInvariant();
-        await using var db = ThumbnailDb.OpenRead();
+        await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
         var item = db.Thumbnail.AsNoTracking().FirstOrDefault(t => t.ProductCode == productCode);
         if (item is null)
             await ctx.RespondAsync($"{Config.Reactions.Failure} Unknown product code {productCode}", ephemeral: true).ConfigureAwait(false);
@@ -67,7 +67,7 @@ internal static partial class Psn
             return;
         }
 
-        await using var db = ThumbnailDb.OpenRead();
+        await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
         var item = db.Thumbnail.AsNoTracking().FirstOrDefault(t => t.ProductCode == productCode);
         if (item is null)
         {

--- a/CompatBot/Commands/Psn.cs
+++ b/CompatBot/Commands/Psn.cs
@@ -25,7 +25,7 @@ internal static partial class Psn
     {
         var ephemeral = !ctx.Channel.IsSpamChannel();
         productCode = productCode.ToUpperInvariant();
-        await using var db = new ThumbnailDb();
+        await using var db = ThumbnailDb.OpenRead();
         var item = db.Thumbnail.AsNoTracking().FirstOrDefault(t => t.ProductCode == productCode);
         if (item is null)
             await ctx.RespondAsync($"{Config.Reactions.Failure} Unknown product code {productCode}", ephemeral: true).ConfigureAwait(false);
@@ -67,7 +67,7 @@ internal static partial class Psn
             return;
         }
 
-        await using var db = new ThumbnailDb();
+        await using var db = ThumbnailDb.OpenRead();
         var item = db.Thumbnail.AsNoTracking().FirstOrDefault(t => t.ProductCode == productCode);
         if (item is null)
         {

--- a/CompatBot/Commands/Sudo.Fix.cs
+++ b/CompatBot/Commands/Sudo.Fix.cs
@@ -25,7 +25,7 @@ internal static partial class Sudo
             try
             {
                 var @fixed = 0;
-                await using var db = BotDb.OpenRead();
+                await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
                 foreach (var warning in db.Warning)
                     if (!string.IsNullOrEmpty(warning.FullReason))
                     {
@@ -54,7 +54,7 @@ internal static partial class Sudo
             try
             {
                 var @fixed = 0;
-                await using var db = BotDb.OpenRead();
+                await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
                 foreach (var warning in db.Warning)
                 {
                     var newReason = await FixChannelMentionAsync(ctx, warning.Reason).ConfigureAwait(false);
@@ -106,7 +106,7 @@ internal static partial class Sudo
         public static async ValueTask TitleMarks(TextCommandContext ctx)
         {
             var changed = 0;
-            await using var db = ThumbnailDb.OpenRead();
+            await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
             foreach (var thumb in db.Thumbnail)
             {
                 if (string.IsNullOrEmpty(thumb.Name))
@@ -135,7 +135,7 @@ internal static partial class Sudo
         public static async ValueTask MetacriticLinks(TextCommandContext ctx, [Description("Remove links for trial and demo versions only")] bool demosOnly = true)
         {
             var changed = 0;
-            await using var db = ThumbnailDb.OpenRead();
+            await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
             foreach (var thumb in db.Thumbnail.Where(t => t.MetacriticId != null))
             {
                 if (demosOnly

--- a/CompatBot/Commands/Sudo.Fix.cs
+++ b/CompatBot/Commands/Sudo.Fix.cs
@@ -25,7 +25,7 @@ internal static partial class Sudo
             try
             {
                 var @fixed = 0;
-                await using var db = new BotDb();
+                await using var db = BotDb.OpenRead();
                 foreach (var warning in db.Warning)
                     if (!string.IsNullOrEmpty(warning.FullReason))
                     {
@@ -54,7 +54,7 @@ internal static partial class Sudo
             try
             {
                 var @fixed = 0;
-                await using var db = new BotDb();
+                await using var db = BotDb.OpenRead();
                 foreach (var warning in db.Warning)
                 {
                     var newReason = await FixChannelMentionAsync(ctx, warning.Reason).ConfigureAwait(false);
@@ -106,7 +106,7 @@ internal static partial class Sudo
         public static async ValueTask TitleMarks(TextCommandContext ctx)
         {
             var changed = 0;
-            await using var db = new ThumbnailDb();
+            await using var db = ThumbnailDb.OpenRead();
             foreach (var thumb in db.Thumbnail)
             {
                 if (string.IsNullOrEmpty(thumb.Name))
@@ -135,7 +135,7 @@ internal static partial class Sudo
         public static async ValueTask MetacriticLinks(TextCommandContext ctx, [Description("Remove links for trial and demo versions only")] bool demosOnly = true)
         {
             var changed = 0;
-            await using var db = new ThumbnailDb();
+            await using var db = ThumbnailDb.OpenRead();
             foreach (var thumb in db.Thumbnail.Where(t => t.MetacriticId != null))
             {
                 if (demosOnly

--- a/CompatBot/Commands/Syscall.cs
+++ b/CompatBot/Commands/Syscall.cs
@@ -26,7 +26,7 @@ internal static class Syscall
             return;
         }
 
-        await using var db = new ThumbnailDb();
+        await using var db = ThumbnailDb.OpenRead();
         if (db.SyscallInfo.Any(sci => sci.Function == search))
         {
             var productInfoList = db.SyscallToProductMap
@@ -119,7 +119,7 @@ internal static class Syscall
         string newFunctionName
     )
     {
-        await using var db = new ThumbnailDb();
+        await using var db = ThumbnailDb.OpenRead();
         var oldMatches = await db.SyscallInfo.Where(sci => sci.Function == oldFunctionName).ToListAsync().ConfigureAwait(false);
         if (oldMatches.Count is 0)
         {
@@ -148,7 +148,7 @@ internal static class Syscall
     private static async ValueTask ReturnSyscallsByGameAsync(SlashCommandContext ctx, string productId, bool ephemeral)
     {
         productId = productId.ToUpperInvariant();
-        await using var db = new ThumbnailDb();
+        await using var db = ThumbnailDb.OpenRead();
         var title = db.Thumbnail.FirstOrDefault(t => t.ProductCode == productId)?.Name;
         title = string.IsNullOrEmpty(title) ? productId : $"[{productId}] {title.Trim(40)}";
         var sysInfoList = db.SyscallToProductMap.AsNoTracking()

--- a/CompatBot/Commands/Syscall.cs
+++ b/CompatBot/Commands/Syscall.cs
@@ -26,7 +26,7 @@ internal static class Syscall
             return;
         }
 
-        await using var db = ThumbnailDb.OpenRead();
+        await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
         if (db.SyscallInfo.Any(sci => sci.Function == search))
         {
             var productInfoList = db.SyscallToProductMap
@@ -119,7 +119,7 @@ internal static class Syscall
         string newFunctionName
     )
     {
-        await using var db = ThumbnailDb.OpenRead();
+        await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
         var oldMatches = await db.SyscallInfo.Where(sci => sci.Function == oldFunctionName).ToListAsync().ConfigureAwait(false);
         if (oldMatches.Count is 0)
         {
@@ -148,7 +148,7 @@ internal static class Syscall
     private static async ValueTask ReturnSyscallsByGameAsync(SlashCommandContext ctx, string productId, bool ephemeral)
     {
         productId = productId.ToUpperInvariant();
-        await using var db = ThumbnailDb.OpenRead();
+        await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
         var title = db.Thumbnail.FirstOrDefault(t => t.ProductCode == productId)?.Name;
         title = string.IsNullOrEmpty(title) ? productId : $"[{productId}] {title.Trim(40)}";
         var sysInfoList = db.SyscallToProductMap.AsNoTracking()

--- a/CompatBot/Commands/Warnings.ListGroup.cs
+++ b/CompatBot/Commands/Warnings.ListGroup.cs
@@ -40,7 +40,7 @@ internal static partial class Warnings
                     new AsciiColumn("Count", alignToRight: true),
                     new AsciiColumn("All time", alignToRight: true)
                 );
-                await using var db = new BotDb();
+                await using var db = BotDb.OpenRead();
                 var query = from warn in db.Warning.AsEnumerable()
                     group warn by warn.DiscordId
                     into userGroup
@@ -84,7 +84,7 @@ internal static partial class Warnings
                     new AsciiColumn("Warnings given", alignToRight: true),
                     new AsciiColumn("Including retracted", alignToRight: true)
                 );
-                await using var db = new BotDb();
+                await using var db = BotDb.OpenRead();
                 var query = from warn in db.Warning.AsEnumerable()
                     group warn by warn.IssuerId
                     into modGroup
@@ -129,7 +129,7 @@ internal static partial class Warnings
                 new AsciiColumn("Reason"),
                 new AsciiColumn("Context", disabled: !ctx.Channel.IsPrivate)
             );
-            await using var db = new BotDb();
+            await using var db = BotDb.OpenRead();
             var query = from warn in db.Warning
                 where warn.IssuerId == moderator.Id && !warn.Retracted
                 orderby warn.Id descending
@@ -169,7 +169,7 @@ internal static partial class Warnings
                 new AsciiColumn("Reason"),
                 new AsciiColumn("Context", disabled: !isMod)
             );
-            await using var db = new BotDb();
+            await using var db = BotDb.OpenRead();
             IOrderedQueryable<Warning> query;
             if (isMod)
                 query = from warn in db.Warning

--- a/CompatBot/Commands/Warnings.ListGroup.cs
+++ b/CompatBot/Commands/Warnings.ListGroup.cs
@@ -40,7 +40,7 @@ internal static partial class Warnings
                     new AsciiColumn("Count", alignToRight: true),
                     new AsciiColumn("All time", alignToRight: true)
                 );
-                await using var db = BotDb.OpenRead();
+                await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
                 var query = from warn in db.Warning.AsEnumerable()
                     group warn by warn.DiscordId
                     into userGroup
@@ -84,7 +84,7 @@ internal static partial class Warnings
                     new AsciiColumn("Warnings given", alignToRight: true),
                     new AsciiColumn("Including retracted", alignToRight: true)
                 );
-                await using var db = BotDb.OpenRead();
+                await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
                 var query = from warn in db.Warning.AsEnumerable()
                     group warn by warn.IssuerId
                     into modGroup
@@ -129,7 +129,7 @@ internal static partial class Warnings
                 new AsciiColumn("Reason"),
                 new AsciiColumn("Context", disabled: !ctx.Channel.IsPrivate)
             );
-            await using var db = BotDb.OpenRead();
+            await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
             var query = from warn in db.Warning
                 where warn.IssuerId == moderator.Id && !warn.Retracted
                 orderby warn.Id descending
@@ -169,7 +169,7 @@ internal static partial class Warnings
                 new AsciiColumn("Reason"),
                 new AsciiColumn("Context", disabled: !isMod)
             );
-            await using var db = BotDb.OpenRead();
+            await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
             IOrderedQueryable<Warning> query;
             if (isMod)
                 query = from warn in db.Warning

--- a/CompatBot/Commands/Warnings.cs
+++ b/CompatBot/Commands/Warnings.cs
@@ -53,7 +53,7 @@ internal static partial class Warnings
         DiscordUser? user = null
     )
     {
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         var warnings = await db.Warning.Where(w => id.Equals(w.Id)).ToListAsync().ConfigureAwait(false);
         if (warnings.Count is 0)
         {
@@ -85,7 +85,7 @@ internal static partial class Warnings
         DiscordUser? user = null
     )
     {
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         var warningsToRemove = await db.Warning.Where(w => w.Id == id).ToListAsync().ConfigureAwait(false);
         foreach (var w in warningsToRemove)
         {
@@ -117,7 +117,7 @@ internal static partial class Warnings
     {
         try
         {
-            await using var db = BotDb.OpenRead();
+            await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
             var warningsToRemove = await db.Warning.Where(w => w.DiscordId == user.Id && !w.Retracted).ToListAsync().ConfigureAwait(false);
             foreach (var w in warningsToRemove)
             {
@@ -146,7 +146,7 @@ internal static partial class Warnings
         DiscordUser? user = null
     )
     {
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         var warn = await db.Warning.FirstOrDefaultAsync(w => w.Id == id).ConfigureAwait(false);
         if (warn is { Retracted: true })
         {
@@ -166,7 +166,7 @@ internal static partial class Warnings
     {
         try
         {
-            await using var db = BotDb.OpenRead();
+            await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
             await db.Warning.AddAsync(
                 new()
                 {
@@ -211,7 +211,7 @@ internal static partial class Warnings
             const bool ephemeral = true;
             int count, removed;
             bool isKot, isDoggo;
-            await using var db = BotDb.OpenRead();
+            await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
             count = await db.Warning.CountAsync(w => w.DiscordId == userId && !w.Retracted).ConfigureAwait(false);
             removed = await db.Warning.CountAsync(w => w.DiscordId == userId && w.Retracted).ConfigureAwait(false);
             isKot = db.Kot.Any(k => k.UserId == userId);

--- a/CompatBot/Commands/Warnings.cs
+++ b/CompatBot/Commands/Warnings.cs
@@ -53,7 +53,7 @@ internal static partial class Warnings
         DiscordUser? user = null
     )
     {
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         var warnings = await db.Warning.Where(w => id.Equals(w.Id)).ToListAsync().ConfigureAwait(false);
         if (warnings.Count is 0)
         {
@@ -85,7 +85,7 @@ internal static partial class Warnings
         DiscordUser? user = null
     )
     {
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         var warningsToRemove = await db.Warning.Where(w => w.Id == id).ToListAsync().ConfigureAwait(false);
         foreach (var w in warningsToRemove)
         {
@@ -117,7 +117,7 @@ internal static partial class Warnings
     {
         try
         {
-            await using var db = new BotDb();
+            await using var db = BotDb.OpenRead();
             var warningsToRemove = await db.Warning.Where(w => w.DiscordId == user.Id && !w.Retracted).ToListAsync().ConfigureAwait(false);
             foreach (var w in warningsToRemove)
             {
@@ -146,7 +146,7 @@ internal static partial class Warnings
         DiscordUser? user = null
     )
     {
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         var warn = await db.Warning.FirstOrDefaultAsync(w => w.Id == id).ConfigureAwait(false);
         if (warn is { Retracted: true })
         {
@@ -166,7 +166,7 @@ internal static partial class Warnings
     {
         try
         {
-            await using var db = new BotDb();
+            await using var db = BotDb.OpenRead();
             await db.Warning.AddAsync(
                 new()
                 {
@@ -211,7 +211,7 @@ internal static partial class Warnings
             const bool ephemeral = true;
             int count, removed;
             bool isKot, isDoggo;
-            await using var db = new BotDb();
+            await using var db = BotDb.OpenRead();
             count = await db.Warning.CountAsync(w => w.DiscordId == userId && !w.Retracted).ConfigureAwait(false);
             removed = await db.Warning.CountAsync(w => w.DiscordId == userId && w.Retracted).ConfigureAwait(false);
             isKot = db.Kot.Any(k => k.UserId == userId);

--- a/CompatBot/CompatBot.csproj
+++ b/CompatBot/CompatBot.csproj
@@ -65,6 +65,7 @@
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.225.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
     <PackageReference Include="Nerdbank.Streams" Version="2.12.87" />
+    <PackageReference Include="Nito.AsyncEx" Version="5.1.2" />
     <PackageReference Include="NLog" Version="5.4.0" />
     <PackageReference Include="NLog.Extensions.Logging" Version="5.4.0" />
     <PackageReference Include="NReco.Text.AhoCorasickDoubleArrayTrie" Version="1.1.1" />

--- a/CompatBot/Database/DbImporter.cs
+++ b/CompatBot/Database/DbImporter.cs
@@ -10,11 +10,11 @@ public static class DbImporter
 {
     public static async Task<bool> UpgradeAsync(CancellationToken cancellationToken)
     {
-        await using (var db = new BotDb())
+        await using (var db = BotDb.OpenWrite())
             if (!await UpgradeAsync(db, cancellationToken).ConfigureAwait(false))
                 return false;
 
-        await using (var db = new ThumbnailDb())
+        await using (var db = ThumbnailDb.OpenWrite())
         {
             if (!await UpgradeAsync(db,cancellationToken).ConfigureAwait(false))
                 return false;
@@ -23,7 +23,7 @@ public static class DbImporter
                 return false;
         }
             
-        await using (var db = new HardwareDb())
+        await using (var db = HardwareDb.OpenWrite())
             if (!await UpgradeAsync(db, cancellationToken).ConfigureAwait(false))
                 return false;
 

--- a/CompatBot/Database/DbImporter.cs
+++ b/CompatBot/Database/DbImporter.cs
@@ -10,11 +10,11 @@ public static class DbImporter
 {
     public static async Task<bool> UpgradeAsync(CancellationToken cancellationToken)
     {
-        await using (var db = BotDb.OpenWrite())
+        await using (var db = await BotDb.OpenWriteAsync().ConfigureAwait(false))
             if (!await UpgradeAsync(db, cancellationToken).ConfigureAwait(false))
                 return false;
 
-        await using (var db = ThumbnailDb.OpenWrite())
+        await using (var db = await ThumbnailDb.OpenWriteAsync().ConfigureAwait(false))
         {
             if (!await UpgradeAsync(db,cancellationToken).ConfigureAwait(false))
                 return false;
@@ -23,7 +23,7 @@ public static class DbImporter
                 return false;
         }
             
-        await using (var db = HardwareDb.OpenWrite())
+        await using (var db = await HardwareDb.OpenWriteAsync().ConfigureAwait(false))
             if (!await UpgradeAsync(db, cancellationToken).ConfigureAwait(false))
                 return false;
 

--- a/CompatBot/Database/Providers/AmdDriverVersionProvider.cs
+++ b/CompatBot/Database/Providers/AmdDriverVersionProvider.cs
@@ -58,7 +58,7 @@ internal static class AmdDriverVersionProvider
             }
     }
 
-    public static async Task<string> GetFromOpenglAsync(string openglVersion, bool autoRefresh = true)
+    public static async ValueTask<string> GetFromOpenglAsync(string openglVersion, bool autoRefresh = true)
     {
         if (OpenglToDriver.TryGetValue(openglVersion, out var result))
             return result;
@@ -111,7 +111,7 @@ internal static class AmdDriverVersionProvider
         return openglVersion;
     }
 
-    public static async Task<string> GetFromVulkanAsync(string vulkanVersion, bool autoRefresh = true)
+    public static async ValueTask<string> GetFromVulkanAsync(string vulkanVersion, bool autoRefresh = true)
     {
         if (!VulkanToDriver.TryGetValue(vulkanVersion, out var result))
             await RefreshAsync().ConfigureAwait(false);

--- a/CompatBot/Database/Providers/ContentFilter.cs
+++ b/CompatBot/Database/Providers/ContentFilter.cs
@@ -18,13 +18,13 @@ internal static class ContentFilter
 
     static ContentFilter() => RebuildMatcher();
 
-    public static Task<Piracystring?> FindTriggerAsync(FilterContext ctx, string str)
+    public static ValueTask<Piracystring?> FindTriggerAsync(FilterContext ctx, string str)
     {
         if (string.IsNullOrEmpty(str))
-            return Task.FromResult((Piracystring?)null);
+            return ValueTask.FromResult((Piracystring?)null);
 
         if (!filters.TryGetValue(ctx, out var matcher))
-            return Task.FromResult((Piracystring?)null);
+            return ValueTask.FromResult((Piracystring?)null);
 
         Piracystring? result = null;
         matcher?.ParseText(str, h =>
@@ -53,7 +53,7 @@ internal static class ContentFilter
             });
         }
 
-        return Task.FromResult(result);
+        return ValueTask.FromResult(result);
     }
 
     public static void RebuildMatcher()
@@ -100,8 +100,7 @@ internal static class ContentFilter
         filters = newFilters;
     }
 
-
-    public static async Task<bool> IsClean(DiscordClient client, DiscordMessage message)
+    public static async ValueTask<bool> IsClean(DiscordClient client, DiscordMessage message)
     {
         if (message.Channel.IsPrivate)
             return true;
@@ -166,7 +165,15 @@ internal static class ContentFilter
         return (trigger.Actions & ~suppressActions & (FilterAction.IssueWarning | FilterAction.RemoveContent)) == 0;
     }
 
-    public static async Task PerformFilterActions(DiscordClient client, DiscordMessage message, Piracystring trigger, FilterAction ignoreFlags = 0, string? triggerContext = null, string? infraction = null, string? warningReason = null)
+    public static async ValueTask PerformFilterActions(
+        DiscordClient client,
+        DiscordMessage message,
+        Piracystring trigger,
+        FilterAction ignoreFlags = 0,
+        string? triggerContext = null,
+        string? infraction = null,
+        string? warningReason = null
+    )
     {
         var severity = ReportSeverity.Low;
         var completedActions = new List<FilterAction>();

--- a/CompatBot/Database/Providers/ContentFilter.cs
+++ b/CompatBot/Database/Providers/ContentFilter.cs
@@ -59,7 +59,7 @@ internal static class ContentFilter
     public static void RebuildMatcher()
     {
         var newFilters = new Dictionary<FilterContext, AhoCorasickDoubleArrayTrie<Piracystring>?>();
-        using var db = new BotDb();
+        using var db = BotDb.OpenRead();
         foreach (FilterContext ctx in Enum.GetValues<FilterContext>())
         {
             var triggerList = db.Piracystring.Where(ps => ps.Disabled == false && ps.Context.HasFlag(ctx)).AsNoTracking()

--- a/CompatBot/Database/Providers/DisabledCommandsProvider.cs
+++ b/CompatBot/Database/Providers/DisabledCommandsProvider.cs
@@ -8,7 +8,7 @@ internal static class DisabledCommandsProvider
     {
         lock (DisabledCommands)
         {
-            using var db = new BotDb();
+            using var db = BotDb.OpenRead();
             foreach (var cmd in db.DisabledCommands.ToList())
                 DisabledCommands.Add(cmd.Command);
         }
@@ -21,7 +21,7 @@ internal static class DisabledCommandsProvider
         lock (DisabledCommands)
             if (DisabledCommands.Add(command))
             {
-                using var db = new BotDb();
+                using var db = BotDb.OpenWrite();
                 db.DisabledCommands.Add(new() {Command = command});
                 db.SaveChanges();
             }
@@ -32,7 +32,7 @@ internal static class DisabledCommandsProvider
         lock (DisabledCommands)
             if (DisabledCommands.Remove(command))
             {
-                using var db = new BotDb();
+                using var db = BotDb.OpenWrite();
                 var cmd = db.DisabledCommands.FirstOrDefault(c => c.Command == command);
                 if (cmd == null)
                     return;
@@ -47,7 +47,7 @@ internal static class DisabledCommandsProvider
         lock (DisabledCommands)
         {
             DisabledCommands.Clear();
-            using var db = new BotDb();
+            using var db = BotDb.OpenWrite();
             db.DisabledCommands.RemoveRange(db.DisabledCommands);
             db.SaveChanges();
         }

--- a/CompatBot/Database/Providers/HwInfoProvider.cs
+++ b/CompatBot/Database/Providers/HwInfoProvider.cs
@@ -11,7 +11,7 @@ internal static class HwInfoProvider
     private static readonly TimeSpan CacheTime = TimeSpan.FromDays(1);
     private static readonly MemoryCache UserCache = new(new MemoryCacheOptions { ExpirationScanFrequency = TimeSpan.FromHours(1) });
 
-    public static async Task AddOrUpdateSystemAsync(DiscordClient client, DiscordMessage msg, NameValueCollection items, CancellationToken cancellationToken)
+    public static async ValueTask AddOrUpdateSystemAsync(DiscordClient client, DiscordMessage msg, NameValueCollection items, CancellationToken cancellationToken)
     {
         var ignoreAuthor = await msg.Author.IsWhitelistedAsync(client, msg.Channel.Guild).ConfigureAwait(false);
         byte counter = 0;

--- a/CompatBot/Database/Providers/HwInfoProvider.cs
+++ b/CompatBot/Database/Providers/HwInfoProvider.cs
@@ -76,8 +76,8 @@ internal static class HwInfoProvider
             OsName = GetName(osType, items),
             OsVersion = items["os_version"],
         };
-        await using var db = new HardwareDb();
-        var existingItem = await db.HwInfo.FindAsync(info.InstallId).ConfigureAwait(false);
+        await using var db = HardwareDb.OpenWrite();
+        var existingItem = await db.HwInfo.FindAsync([info.InstallId], cancellationToken: cancellationToken).ConfigureAwait(false);
         if (existingItem is null)
             db.HwInfo.Add(info);
         else if (existingItem.Timestamp <= info.Timestamp)

--- a/CompatBot/Database/Providers/HwInfoProvider.cs
+++ b/CompatBot/Database/Providers/HwInfoProvider.cs
@@ -76,7 +76,7 @@ internal static class HwInfoProvider
             OsName = GetName(osType, items),
             OsVersion = items["os_version"],
         };
-        await using var db = HardwareDb.OpenWrite();
+        await using var db = await HardwareDb.OpenWriteAsync().ConfigureAwait(false);
         var existingItem = await db.HwInfo.FindAsync([info.InstallId], cancellationToken: cancellationToken).ConfigureAwait(false);
         if (existingItem is null)
             db.HwInfo.Add(info);

--- a/CompatBot/Database/Providers/InviteWhitelistProvider.cs
+++ b/CompatBot/Database/Providers/InviteWhitelistProvider.cs
@@ -7,7 +7,7 @@ internal static class InviteWhitelistProvider
 {
     public static bool IsWhitelisted(ulong guildId)
     {
-        using var db = new BotDb();
+        using var db = BotDb.OpenRead();
         return db.WhitelistedInvites.Any(i => i.GuildId == guildId);
     }
 
@@ -15,9 +15,9 @@ internal static class InviteWhitelistProvider
     {
         var code = string.IsNullOrWhiteSpace(invite.Code) ? null : invite.Code;
         var name = string.IsNullOrWhiteSpace(invite.Guild.Name) ? null : invite.Guild.Name;
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenWrite();
         var whitelistedInvite = await db.WhitelistedInvites.FirstOrDefaultAsync(i => i.GuildId == invite.Guild.Id);
-        if (whitelistedInvite == null)
+        if (whitelistedInvite is null)
             return false;
 
         if (name != null && name != whitelistedInvite.Name)
@@ -35,7 +35,7 @@ internal static class InviteWhitelistProvider
 
         var code = invite.IsRevoked || string.IsNullOrWhiteSpace(invite.Code) ? null : invite.Code;
         var name = string.IsNullOrWhiteSpace(invite.Guild.Name) ? null : invite.Guild.Name;
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenWrite();
         await db.WhitelistedInvites.AddAsync(new WhitelistedInvite { GuildId = invite.Guild.Id, Name = name, InviteCode = code }).ConfigureAwait(false);
         await db.SaveChangesAsync().ConfigureAwait(false);
         return true;
@@ -46,7 +46,7 @@ internal static class InviteWhitelistProvider
         if (IsWhitelisted(guildId))
             return false;
 
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenWrite();
         await db.WhitelistedInvites.AddAsync(new WhitelistedInvite {GuildId = guildId}).ConfigureAwait(false);
         await db.SaveChangesAsync().ConfigureAwait(false);
         return true;
@@ -54,7 +54,7 @@ internal static class InviteWhitelistProvider
 
     public static async Task<bool> RemoveAsync(int id)
     {
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenWrite();
         var dbItem = await db.WhitelistedInvites.FirstOrDefaultAsync(i => i.Id == id).ConfigureAwait(false);
         if (dbItem == null)
             return false;
@@ -68,13 +68,13 @@ internal static class InviteWhitelistProvider
     {
         while (!Config.Cts.IsCancellationRequested)
         {
-            await using var db = new BotDb();
+            await using var db = BotDb.OpenWrite();
             foreach (var invite in db.WhitelistedInvites.Where(i => i.InviteCode != null))
             {
                 try
                 {
                     var result = await client.GetInviteByCodeAsync(invite.InviteCode).ConfigureAwait(false);
-                    if (result?.IsRevoked == true)
+                    if (result.IsRevoked)
                         invite.InviteCode = null;
                 }
                 catch (NotFoundException)

--- a/CompatBot/Database/Providers/InviteWhitelistProvider.cs
+++ b/CompatBot/Database/Providers/InviteWhitelistProvider.cs
@@ -11,7 +11,7 @@ internal static class InviteWhitelistProvider
         return db.WhitelistedInvites.Any(i => i.GuildId == guildId);
     }
 
-    public static async Task<bool> IsWhitelistedAsync(DiscordInvite invite)
+    public static async ValueTask<bool> IsWhitelistedAsync(DiscordInvite invite)
     {
         var code = string.IsNullOrWhiteSpace(invite.Code) ? null : invite.Code;
         var name = string.IsNullOrWhiteSpace(invite.Guild.Name) ? null : invite.Guild.Name;
@@ -28,7 +28,7 @@ internal static class InviteWhitelistProvider
         return true;
     }
 
-    public static async Task<bool> AddAsync(DiscordInvite invite)
+    public static async ValueTask<bool> AddAsync(DiscordInvite invite)
     {
         if (await IsWhitelistedAsync(invite).ConfigureAwait(false))
             return false;
@@ -41,7 +41,7 @@ internal static class InviteWhitelistProvider
         return true;
     }
 
-    public static async Task<bool> AddAsync(ulong guildId)
+    public static async ValueTask<bool> AddAsync(ulong guildId)
     {
         if (IsWhitelisted(guildId))
             return false;
@@ -52,7 +52,7 @@ internal static class InviteWhitelistProvider
         return true;
     }
 
-    public static async Task<bool> RemoveAsync(int id)
+    public static async ValueTask<bool> RemoveAsync(int id)
     {
         await using var db = BotDb.OpenWrite();
         var dbItem = await db.WhitelistedInvites.FirstOrDefaultAsync(i => i.Id == id).ConfigureAwait(false);

--- a/CompatBot/Database/Providers/ModProvider.cs
+++ b/CompatBot/Database/Providers/ModProvider.cs
@@ -17,7 +17,7 @@ internal static class ModProvider
     public static bool IsMod(ulong userId) => Moderators.ContainsKey(userId);
     public static bool IsSudoer(ulong userId) => Moderators.TryGetValue(userId, out var mod) && mod.Sudoer;
 
-    public static async Task<bool> AddAsync(ulong userId)
+    public static async ValueTask<bool> AddAsync(ulong userId)
     {
         if (IsMod(userId))
             return false;
@@ -36,7 +36,7 @@ internal static class ModProvider
         return true;
     }
 
-    public static async Task<bool> RemoveAsync(ulong userId)
+    public static async ValueTask<bool> RemoveAsync(ulong userId)
     {
         if (!Moderators.ContainsKey(userId))
             return false;
@@ -58,7 +58,7 @@ internal static class ModProvider
         return true;
     }
 
-    public static async Task<bool> MakeSudoerAsync(ulong userId)
+    public static async ValueTask<bool> MakeSudoerAsync(ulong userId)
     {
         if (!Moderators.TryGetValue(userId, out var mod) || mod.Sudoer)
             return false;
@@ -74,7 +74,7 @@ internal static class ModProvider
         return true;
     }
 
-    public static async Task<bool> UnmakeSudoerAsync(ulong userId)
+    public static async ValueTask<bool> UnmakeSudoerAsync(ulong userId)
     {
         if (!Moderators.TryGetValue(userId, out var mod) || !mod.Sudoer)
             return false;
@@ -91,6 +91,7 @@ internal static class ModProvider
         return true;
     }
 
+    [Obsolete]
     public static async Task SyncRolesAsync(DiscordGuild guild)
     {
         Config.Log.Debug("Syncing moderator list to the sudoer role");

--- a/CompatBot/Database/Providers/ModProvider.cs
+++ b/CompatBot/Database/Providers/ModProvider.cs
@@ -23,7 +23,7 @@ internal static class ModProvider
             return false;
 
         var newMod = new Moderator {DiscordId = userId};
-        await using var db = BotDb.OpenWrite();
+        await using var db = await BotDb.OpenWriteAsync().ConfigureAwait(false);
         await db.Moderator.AddAsync(newMod).ConfigureAwait(false);
         await db.SaveChangesAsync().ConfigureAwait(false);
         lock (Moderators)
@@ -41,7 +41,7 @@ internal static class ModProvider
         if (!Moderators.ContainsKey(userId))
             return false;
 
-        await using var db = BotDb.OpenWrite();
+        await using var db = await BotDb.OpenWriteAsync().ConfigureAwait(false);
         var mod = await db.Moderator.FirstOrDefaultAsync(m => m.DiscordId == userId).ConfigureAwait(false);
         if (mod is not null)
         {
@@ -63,7 +63,7 @@ internal static class ModProvider
         if (!Moderators.TryGetValue(userId, out var mod) || mod.Sudoer)
             return false;
 
-        await using var db = BotDb.OpenWrite();
+        await using var db = await BotDb.OpenWriteAsync().ConfigureAwait(false);
         var dbMod = await db.Moderator.FirstOrDefaultAsync(m => m.DiscordId == userId).ConfigureAwait(false);
         if (dbMod is not null)
         {
@@ -79,7 +79,7 @@ internal static class ModProvider
         if (!Moderators.TryGetValue(userId, out var mod) || !mod.Sudoer)
             return false;
 
-        await using var db = BotDb.OpenWrite();
+        await using var db = await BotDb.OpenWriteAsync().ConfigureAwait(false);
         var dbMod = await db.Moderator.FirstOrDefaultAsync(m => m.DiscordId == userId).ConfigureAwait(false);
         if (dbMod is not null)
         {

--- a/CompatBot/Database/Providers/ScrapeStateProvider.cs
+++ b/CompatBot/Database/Providers/ScrapeStateProvider.cs
@@ -29,7 +29,7 @@ internal static class ScrapeStateProvider
         return false;
     }
 
-    public static async Task SetLastRunTimestampAsync(string locale, string? containerId = null)
+    public static async ValueTask SetLastRunTimestampAsync(string locale, string? containerId = null)
     {
         if (string.IsNullOrEmpty(locale))
             throw new ArgumentException("Locale is mandatory", nameof(locale));

--- a/CompatBot/Database/Providers/SqlConfiguration.cs
+++ b/CompatBot/Database/Providers/SqlConfiguration.cs
@@ -10,7 +10,7 @@ internal static class SqlConfiguration
 
     public static async ValueTask RestoreAsync()
     {
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         var setVars = await db.BotState.AsNoTracking().Where(v => v.Key.StartsWith(ConfigVarPrefix)).ToListAsync().ConfigureAwait(false);
         if (setVars.Count is 0)
             return;

--- a/CompatBot/Database/Providers/SqlConfiguration.cs
+++ b/CompatBot/Database/Providers/SqlConfiguration.cs
@@ -8,40 +8,41 @@ internal static class SqlConfiguration
 {
     internal const string ConfigVarPrefix = "ENV-";
 
-    public static async Task RestoreAsync()
+    public static async ValueTask RestoreAsync()
     {
         await using var db = BotDb.OpenRead();
         var setVars = await db.BotState.AsNoTracking().Where(v => v.Key.StartsWith(ConfigVarPrefix)).ToListAsync().ConfigureAwait(false);
-        if (setVars.Any())
+        if (setVars.Count is 0)
+            return;
+        
+        foreach (var stateVar in setVars)
+            if (stateVar.Value is string value)
+                Config.InMemorySettings[stateVar.Key[ConfigVarPrefix.Length ..]] = value;
+        if (!Config.InMemorySettings.TryGetValue(nameof(Config.GoogleApiCredentials), out var googleCreds) ||
+            string.IsNullOrEmpty(googleCreds))
         {
-            foreach (var stateVar in setVars)
-                if (stateVar.Value is string value)
-                    Config.InMemorySettings[stateVar.Key[ConfigVarPrefix.Length ..]] = value;
-            if (!Config.InMemorySettings.TryGetValue(nameof(Config.GoogleApiCredentials), out var googleCreds) || string.IsNullOrEmpty(googleCreds))
+            if (Path.Exists(Config.GoogleApiConfigPath))
             {
-                if (Path.Exists(Config.GoogleApiConfigPath))
+                Config.Log.Info("Migrating Google API credentials storage from file to db…");
+                try
                 {
-                    Config.Log.Info("Migrating Google API credentials storage from file to db…");
-                    try
+                    googleCreds = await File.ReadAllTextAsync(Config.GoogleApiConfigPath).ConfigureAwait(false);
+                    if (GoogleDriveHandler.ValidateCredentials(googleCreds))
                     {
-                        googleCreds = await File.ReadAllTextAsync(Config.GoogleApiConfigPath).ConfigureAwait(false);
-                        if (GoogleDriveHandler.ValidateCredentials(googleCreds))
-                        {
-                            Config.InMemorySettings[nameof(Config.GoogleApiCredentials)] = googleCreds;
-                            Config.Log.Info("Successfully migrated Google API credentials");
-                        }
-                        else
-                        {
-                            Config.Log.Error("Failed to migrate Google API credentials");
-                        }
+                        Config.InMemorySettings[nameof(Config.GoogleApiCredentials)] = googleCreds;
+                        Config.Log.Info("Successfully migrated Google API credentials");
                     }
-                    catch (Exception e)
+                    else
                     {
-                        Config.Log.Error(e, "Failed to migrate Google API credentials");
+                        Config.Log.Error("Failed to migrate Google API credentials");
                     }
                 }
+                catch (Exception e)
+                {
+                    Config.Log.Error(e, "Failed to migrate Google API credentials");
+                }
             }
-            Config.RebuildConfiguration();
         }
+        Config.RebuildConfiguration();
     }
 }

--- a/CompatBot/Database/Providers/SqlConfiguration.cs
+++ b/CompatBot/Database/Providers/SqlConfiguration.cs
@@ -10,7 +10,7 @@ internal static class SqlConfiguration
 
     public static async Task RestoreAsync()
     {
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         var setVars = await db.BotState.AsNoTracking().Where(v => v.Key.StartsWith(ConfigVarPrefix)).ToListAsync().ConfigureAwait(false);
         if (setVars.Any())
         {

--- a/CompatBot/Database/Providers/StatsStorage.cs
+++ b/CompatBot/Database/Providers/StatsStorage.cs
@@ -64,14 +64,14 @@ internal static class StatsStorage
             .ToList();
     }
     
-    public static async Task SaveAsync(bool wait = false)
+    public static async ValueTask SaveAsync(bool wait = false)
     {
         if (await Barrier.WaitAsync(0).ConfigureAwait(false))
         {
             try
             {
                 Config.Log.Debug("Got stats saving lock");
-                await using var db = new BotDb();
+                await using var db = BotDb.OpenWrite();
                 foreach (var (category, cache) in AllCaches)
                 {
                     var entries = cache.GetCacheEntries<string>();
@@ -126,7 +126,7 @@ internal static class StatsStorage
     public static async Task RestoreAsync()
     {
         var now = DateTime.UtcNow;
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenWrite();
         foreach (var (category, cache) in AllCaches)
         {
             var entries = await db.Stats.Where(e => e.Category == category).ToListAsync().ConfigureAwait(false);

--- a/CompatBot/Database/Providers/StatsStorage.cs
+++ b/CompatBot/Database/Providers/StatsStorage.cs
@@ -71,7 +71,7 @@ internal static class StatsStorage
             try
             {
                 Config.Log.Debug("Got stats saving lock");
-                await using var db = BotDb.OpenWrite();
+                await using var db = await BotDb.OpenWriteAsync().ConfigureAwait(false);
                 foreach (var (category, cache) in AllCaches)
                 {
                     var entries = cache.GetCacheEntries<string>();
@@ -126,7 +126,7 @@ internal static class StatsStorage
     public static async ValueTask RestoreAsync()
     {
         var now = DateTime.UtcNow;
-        await using var db = BotDb.OpenWrite();
+        await using var db = await BotDb.OpenWriteAsync().ConfigureAwait(false);
         foreach (var (category, cache) in AllCaches)
         {
             var entries = await db.Stats.Where(e => e.Category == category).ToListAsync().ConfigureAwait(false);

--- a/CompatBot/Database/Providers/StatsStorage.cs
+++ b/CompatBot/Database/Providers/StatsStorage.cs
@@ -123,7 +123,7 @@ internal static class StatsStorage
         }
     }
 
-    public static async Task RestoreAsync()
+    public static async ValueTask RestoreAsync()
     {
         var now = DateTime.UtcNow;
         await using var db = BotDb.OpenWrite();

--- a/CompatBot/Database/Providers/SyscallInfoProvider.cs
+++ b/CompatBot/Database/Providers/SyscallInfoProvider.cs
@@ -8,7 +8,7 @@ internal static class SyscallInfoProvider
 {
     private static readonly SemaphoreSlim Limiter = new(1, 1);
 
-    public static async Task SaveAsync(TSyscallStats syscallInfo)
+    public static async ValueTask SaveAsync(TSyscallStats syscallInfo)
     {
         if (syscallInfo.Count == 0)
             return;
@@ -45,7 +45,7 @@ internal static class SyscallInfoProvider
         }
     }
 
-    public static async Task<(int funcs, int links)> FixInvalidFunctionNamesAsync()
+    public static async ValueTask<(int funcs, int links)> FixInvalidFunctionNamesAsync()
     {
         var syscallStats = new TSyscallStats();
         int funcs, links = 0;
@@ -103,7 +103,7 @@ internal static class SyscallInfoProvider
         return (funcs, links);
     }
 
-    public static async Task<(int funcs, int links)> FixDuplicatesAsync()
+    public static async ValueTask<(int funcs, int links)> FixDuplicatesAsync()
     {
         int funcs = 0, links = 0;
         await using var db = ThumbnailDb.OpenWrite();

--- a/CompatBot/Database/Providers/SyscallInfoProvider.cs
+++ b/CompatBot/Database/Providers/SyscallInfoProvider.cs
@@ -17,7 +17,7 @@ internal static class SyscallInfoProvider
         {
             try
             {
-                await using var db = ThumbnailDb.OpenWrite();
+                await using var db = await ThumbnailDb.OpenWriteAsync().ConfigureAwait(false);
                 foreach (var productCodeMap in syscallInfo)
                 {
                     var product = db.Thumbnail.AsNoTracking().FirstOrDefault(t => t.ProductCode == productCodeMap.Key)
@@ -49,7 +49,7 @@ internal static class SyscallInfoProvider
     {
         var syscallStats = new TSyscallStats();
         int funcs, links = 0;
-        await using var db = ThumbnailDb.OpenWrite();
+        await using var db = await ThumbnailDb.OpenWriteAsync().ConfigureAwait(false);
         var funcsToRemove = new List<SyscallInfo>(0);
         try
         {
@@ -106,7 +106,7 @@ internal static class SyscallInfoProvider
     public static async ValueTask<(int funcs, int links)> FixDuplicatesAsync()
     {
         int funcs = 0, links = 0;
-        await using var db = ThumbnailDb.OpenWrite();
+        await using var db = await ThumbnailDb.OpenWriteAsync().ConfigureAwait(false);
         var duplicateFunctionNames = await db.SyscallInfo.Where(sci => db.SyscallInfo.Count(isci => isci.Function == sci.Function) > 1).Distinct().ToListAsync().ConfigureAwait(false);
         if (duplicateFunctionNames.Count == 0)
             return (0, 0);

--- a/CompatBot/Database/Providers/SyscallInfoProvider.cs
+++ b/CompatBot/Database/Providers/SyscallInfoProvider.cs
@@ -17,7 +17,7 @@ internal static class SyscallInfoProvider
         {
             try
             {
-                await using var db = new ThumbnailDb();
+                await using var db = ThumbnailDb.OpenWrite();
                 foreach (var productCodeMap in syscallInfo)
                 {
                     var product = db.Thumbnail.AsNoTracking().FirstOrDefault(t => t.ProductCode == productCodeMap.Key)
@@ -49,7 +49,7 @@ internal static class SyscallInfoProvider
     {
         var syscallStats = new TSyscallStats();
         int funcs, links = 0;
-        await using var db = new ThumbnailDb();
+        await using var db = ThumbnailDb.OpenWrite();
         var funcsToRemove = new List<SyscallInfo>(0);
         try
         {
@@ -106,7 +106,7 @@ internal static class SyscallInfoProvider
     public static async Task<(int funcs, int links)> FixDuplicatesAsync()
     {
         int funcs = 0, links = 0;
-        await using var db = new ThumbnailDb();
+        await using var db = ThumbnailDb.OpenWrite();
         var duplicateFunctionNames = await db.SyscallInfo.Where(sci => db.SyscallInfo.Count(isci => isci.Function == sci.Function) > 1).Distinct().ToListAsync().ConfigureAwait(false);
         if (duplicateFunctionNames.Count == 0)
             return (0, 0);

--- a/CompatBot/Database/Providers/ThumbnailProvider.cs
+++ b/CompatBot/Database/Providers/ThumbnailProvider.cs
@@ -12,7 +12,7 @@ internal static class ThumbnailProvider
     private static readonly PsnClient.Client PsnClient = new();
     private static readonly MemoryCache ColorCache = new(new MemoryCacheOptions{ ExpirationScanFrequency = TimeSpan.FromDays(1) });
 
-    public static async Task<string?> GetThumbnailUrlAsync(this DiscordClient client, string? productCode)
+    public static async ValueTask<string?> GetThumbnailUrlAsync(this DiscordClient client, string? productCode)
     {
         if (string.IsNullOrEmpty(productCode))
             return null;
@@ -137,7 +137,7 @@ internal static class ThumbnailProvider
         return (info.EmbeddableUrl, color);
     }
 
-    public static async Task<(string? url, byte[]? image)> GetEmbeddableUrlAsync(DiscordClient client, string contentId, string url)
+    public static async ValueTask<(string? url, byte[]? image)> GetEmbeddableUrlAsync(DiscordClient client, string contentId, string url)
     {
         try
         {
@@ -164,7 +164,7 @@ internal static class ThumbnailProvider
         return (null, null);
     }
 
-    public static async Task<DiscordColor?> GetImageColorAsync(string? url, DiscordColor? defaultColor = null)
+    public static async ValueTask<DiscordColor?> GetImageColorAsync(string? url, DiscordColor? defaultColor = null)
     {
         try
         {

--- a/CompatBot/Database/Providers/ThumbnailProvider.cs
+++ b/CompatBot/Database/Providers/ThumbnailProvider.cs
@@ -22,7 +22,7 @@ internal static class ThumbnailProvider
         if (tmdbInfo is { Icon.Url: string tmdbIconUrl })
             return tmdbIconUrl;
 
-        await using var db = new ThumbnailDb();
+        await using var db = ThumbnailDb.OpenWrite();
         var thumb = await db.Thumbnail.FirstOrDefaultAsync(t => t.ProductCode == productCode).ConfigureAwait(false);
         //todo: add search task if not found
         if (thumb?.EmbeddableUrl is {Length: >0} embeddableUrl)
@@ -55,13 +55,13 @@ internal static class ThumbnailProvider
         return embedUrl;
     }
 
-    public static async Task<string?> GetTitleNameAsync(string? productCode, CancellationToken cancellationToken)
+    public static async ValueTask<string?> GetTitleNameAsync(string? productCode, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(productCode))
             return null;
 
         productCode = productCode.ToUpperInvariant();
-        await using var db = new ThumbnailDb();
+        await using var db = ThumbnailDb.OpenWrite();
         var thumb = await db.Thumbnail.FirstOrDefaultAsync(
             t => t.ProductCode == productCode,
             cancellationToken: cancellationToken
@@ -93,13 +93,13 @@ internal static class ThumbnailProvider
         return title;
     }
 
-    public static async Task<(string? url, DiscordColor color)> GetThumbnailUrlWithColorAsync(DiscordClient client, string contentId, DiscordColor defaultColor, string? url = null)
+    public static async ValueTask<(string? url, DiscordColor color)> GetThumbnailUrlWithColorAsync(DiscordClient client, string contentId, DiscordColor defaultColor, string? url = null)
     {
         if (string.IsNullOrEmpty(contentId))
             throw new ArgumentException("ContentID can't be empty", nameof(contentId));
 
         contentId = contentId.ToUpperInvariant();
-        await using var db = new ThumbnailDb();
+        await using var db = ThumbnailDb.OpenWrite();
         var info = await db.Thumbnail.FirstOrDefaultAsync(ti => ti.ContentId == contentId, Config.Cts.Token).ConfigureAwait(false);
         info ??= new() {Url = url};
         if (info.Url is null)

--- a/CompatBot/Database/Providers/ThumbnailProvider.cs
+++ b/CompatBot/Database/Providers/ThumbnailProvider.cs
@@ -22,7 +22,7 @@ internal static class ThumbnailProvider
         if (tmdbInfo is { Icon.Url: string tmdbIconUrl })
             return tmdbIconUrl;
 
-        await using (var db = ThumbnailDb.OpenWrite())
+        await using (var db = await ThumbnailDb.OpenWriteAsync().ConfigureAwait(false))
         {
             //todo: add search task if not found
             if (await db.Thumbnail
@@ -35,7 +35,7 @@ internal static class ThumbnailProvider
             }
         }
 
-        await using var wdb = ThumbnailDb.OpenWrite();
+        await using var wdb = await ThumbnailDb.OpenWriteAsync().ConfigureAwait(false);
         var thumb = await wdb.Thumbnail.FirstOrDefaultAsync(t => t.ProductCode == productCode).ConfigureAwait(false);
         if (string.IsNullOrEmpty(thumb?.Url) || !ScrapeStateProvider.IsFresh(thumb.Timestamp))
         {
@@ -70,7 +70,7 @@ internal static class ThumbnailProvider
             return null;
 
         productCode = productCode.ToUpperInvariant();
-        await using (var db = ThumbnailDb.OpenRead())
+        await using (var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false))
         {
             if (await db.Thumbnail
                     .AsNoTracking()
@@ -82,7 +82,7 @@ internal static class ThumbnailProvider
             }
         }
 
-        await using var wdb = ThumbnailDb.OpenWrite();
+        await using var wdb = await ThumbnailDb.OpenWriteAsync().ConfigureAwait(false);
         var thumb = await wdb.Thumbnail.FirstOrDefaultAsync(
             t => t.ProductCode == productCode,
             cancellationToken: cancellationToken
@@ -118,7 +118,7 @@ internal static class ThumbnailProvider
             throw new ArgumentException("ContentID can't be empty", nameof(contentId));
 
         contentId = contentId.ToUpperInvariant();
-        await using var db = ThumbnailDb.OpenWrite(); //todo: fix this if it's ever get re-used
+        await using var db = await ThumbnailDb.OpenWriteAsync().ConfigureAwait(false); //todo: fix this if it's ever get re-used
         var info = await db.Thumbnail.FirstOrDefaultAsync(ti => ti.ContentId == contentId, Config.Cts.Token).ConfigureAwait(false);
         info ??= new() {Url = url};
         if (info.Url is null)

--- a/CompatBot/Database/Providers/ThumbnailProvider.cs
+++ b/CompatBot/Database/Providers/ThumbnailProvider.cs
@@ -22,23 +22,32 @@ internal static class ThumbnailProvider
         if (tmdbInfo is { Icon.Url: string tmdbIconUrl })
             return tmdbIconUrl;
 
-        await using var db = ThumbnailDb.OpenWrite();
-        var thumb = await db.Thumbnail.FirstOrDefaultAsync(t => t.ProductCode == productCode).ConfigureAwait(false);
-        //todo: add search task if not found
-        if (thumb?.EmbeddableUrl is {Length: >0} embeddableUrl)
-            return embeddableUrl;
+        await using (var db = ThumbnailDb.OpenWrite())
+        {
+            //todo: add search task if not found
+            if (await db.Thumbnail
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(t => t.ProductCode == productCode)
+                    .ConfigureAwait(false) is { EmbeddableUrl: { Length: > 0 } embeddableUrl }
+            )
+            {
+                return embeddableUrl;
+            }
+        }
 
+        await using var wdb = ThumbnailDb.OpenWrite();
+        var thumb = await wdb.Thumbnail.FirstOrDefaultAsync(t => t.ProductCode == productCode).ConfigureAwait(false);
         if (string.IsNullOrEmpty(thumb?.Url) || !ScrapeStateProvider.IsFresh(thumb.Timestamp))
         {
             var gameTdbCoverUrl = await GameTdbScraper.GetThumbAsync(productCode).ConfigureAwait(false);
             if (!string.IsNullOrEmpty(gameTdbCoverUrl))
             {
                 if (thumb is null)
-                    thumb = (await db.Thumbnail.AddAsync(new() {ProductCode = productCode, Url = gameTdbCoverUrl}).ConfigureAwait(false)).Entity;
+                    thumb = (await wdb.Thumbnail.AddAsync(new() {ProductCode = productCode, Url = gameTdbCoverUrl}).ConfigureAwait(false)).Entity;
                 else
                     thumb.Url = gameTdbCoverUrl;
                 thumb.Timestamp = DateTime.UtcNow.Ticks;
-                await db.SaveChangesAsync().ConfigureAwait(false);
+                await wdb.SaveChangesAsync().ConfigureAwait(false);
             }
         }
 
@@ -51,7 +60,7 @@ internal static class ThumbnailProvider
             return null;
             
         thumb.EmbeddableUrl = embedUrl;
-        await db.SaveChangesAsync().ConfigureAwait(false);
+        await wdb.SaveChangesAsync().ConfigureAwait(false);
         return embedUrl;
     }
 
@@ -61,28 +70,37 @@ internal static class ThumbnailProvider
             return null;
 
         productCode = productCode.ToUpperInvariant();
-        await using var db = ThumbnailDb.OpenWrite();
-        var thumb = await db.Thumbnail.FirstOrDefaultAsync(
+        await using (var db = ThumbnailDb.OpenRead())
+        {
+            if (await db.Thumbnail
+                    .AsNoTracking()
+                    .FirstOrDefaultAsync(t => t.ProductCode == productCode, cancellationToken: cancellationToken)
+                    .ConfigureAwait(false) is { Name: { Length: > 0 } result }
+               )
+            {
+                return result;
+            }
+        }
+
+        await using var wdb = ThumbnailDb.OpenWrite();
+        var thumb = await wdb.Thumbnail.FirstOrDefaultAsync(
             t => t.ProductCode == productCode,
             cancellationToken: cancellationToken
         ).ConfigureAwait(false);
-        if (thumb?.Name is string result)
-            return result;
-
         var title = (await PsnClient.GetTitleMetaAsync(productCode, cancellationToken).ConfigureAwait(false))?.Name;
         try
         {
             if (!string.IsNullOrEmpty(title))
             {
-                if (thumb == null)
-                    await db.Thumbnail.AddAsync(new()
+                if (thumb is null)
+                    await wdb.Thumbnail.AddAsync(new()
                     {
                         ProductCode = productCode,
                         Name = title,
                     }, cancellationToken).ConfigureAwait(false);
                 else
                     thumb.Name = title;
-                await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+                await wdb.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
             }
         }
         catch (Exception e)
@@ -93,13 +111,14 @@ internal static class ThumbnailProvider
         return title;
     }
 
+    [Obsolete]
     public static async ValueTask<(string? url, DiscordColor color)> GetThumbnailUrlWithColorAsync(DiscordClient client, string contentId, DiscordColor defaultColor, string? url = null)
     {
         if (string.IsNullOrEmpty(contentId))
             throw new ArgumentException("ContentID can't be empty", nameof(contentId));
 
         contentId = contentId.ToUpperInvariant();
-        await using var db = ThumbnailDb.OpenWrite();
+        await using var db = ThumbnailDb.OpenWrite(); //todo: fix this if it's ever get re-used
         var info = await db.Thumbnail.FirstOrDefaultAsync(ti => ti.ContentId == contentId, Config.Cts.Token).ConfigureAwait(false);
         info ??= new() {Url = url};
         if (info.Url is null)

--- a/CompatBot/Database/Providers/TitleUpdateInfoProvider.cs
+++ b/CompatBot/Database/Providers/TitleUpdateInfoProvider.cs
@@ -7,8 +7,13 @@ namespace CompatBot.Database.Providers;
 public static class TitleUpdateInfoProvider
 {
     private static readonly PsnClient.Client Client = new();
+    private static readonly XmlSerializer XmlSerializer = new(typeof(TitlePatch));
 
     public static async ValueTask<TitlePatch?> GetAsync(string? productId, CancellationToken cancellationToken)
+        => await GetCachedAsync(productId, false).ConfigureAwait(false)
+           ?? await GetFromApiAsync(productId, cancellationToken).ConfigureAwait(false);
+
+    private static async ValueTask<TitlePatch?> GetFromApiAsync(string? productId, CancellationToken cancellationToken)
     {
         if (string.IsNullOrEmpty(productId))
             return default;
@@ -32,21 +37,27 @@ public static class TitleUpdateInfoProvider
                 updateInfo.Timestamp = DateTime.UtcNow.Ticks;
             await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
-        if (update?.Tag?.Packages?.Length is null or 0)
-        {
-            await using var db = ThumbnailDb.OpenRead();
-            var updateInfo = db.GameUpdateInfo.AsNoTracking().FirstOrDefault(ui => ui.ProductCode == productId);
-            if (updateInfo is null)
-                return update;
+        if (update is not {Tag.Packages.Length: >0})
+            return await GetCachedAsync(productId, true).ConfigureAwait(false);
+        return update;
+    }
 
-            await using var memStream = Config.MemoryStreamManager.GetStream(Encoding.UTF8.GetBytes(updateInfo.MetaXml));
-            var xmlSerializer = new XmlSerializer(typeof(TitlePatch));
-            update = (TitlePatch?)xmlSerializer.Deserialize(memStream);
-            if (update is not null)
-                update.OfflineCacheTimestamp = updateInfo.Timestamp.AsUtc();
+    private static async ValueTask<TitlePatch?> GetCachedAsync(string? productId, bool returnStale = false)
+    {
+        await using var db = ThumbnailDb.OpenRead();
+        var updateInfo = db.GameUpdateInfo
+            .AsNoTracking()
+            .FirstOrDefault(ui => ui.ProductCode == productId);
+        if (updateInfo is null
+            || (!returnStale && updateInfo.Timestamp < DateTime.UtcNow.AddDays(-1).Ticks))
+            return null;
 
-            return update;
-        }
+        await using var memStream = Config.MemoryStreamManager.GetStream(Encoding.UTF8.GetBytes(updateInfo.MetaXml));
+        var update = (TitlePatch?)XmlSerializer.Deserialize(memStream);
+        if (update is null)
+            return null;
+        
+        update.OfflineCacheTimestamp = updateInfo.Timestamp.AsUtc();
         return update;
     }
 

--- a/CompatBot/Database/Providers/TitleUpdateInfoProvider.cs
+++ b/CompatBot/Database/Providers/TitleUpdateInfoProvider.cs
@@ -35,7 +35,7 @@ public static class TitleUpdateInfoProvider
         if (update?.Tag?.Packages?.Length is null or 0)
         {
             await using var db = ThumbnailDb.OpenRead();
-            var updateInfo = db.GameUpdateInfo.FirstOrDefault(ui => ui.ProductCode == productId);
+            var updateInfo = db.GameUpdateInfo.AsNoTracking().FirstOrDefault(ui => ui.ProductCode == productId);
             if (updateInfo is null)
                 return update;
 

--- a/CompatBot/Database/Providers/TitleUpdateInfoProvider.cs
+++ b/CompatBot/Database/Providers/TitleUpdateInfoProvider.cs
@@ -23,7 +23,7 @@ public static class TitleUpdateInfoProvider
         if (xml is {Length: > 10})
         {
             var xmlChecksum = xml.GetStableHash();
-            await using var db = ThumbnailDb.OpenWrite();
+            await using var db = await ThumbnailDb.OpenWriteAsync().ConfigureAwait(false);
             var updateInfo = db.GameUpdateInfo.FirstOrDefault(ui => ui.ProductCode == productId);
             if (updateInfo is null)
                 db.GameUpdateInfo.Add(new() {ProductCode = productId, MetaHash = xmlChecksum, MetaXml = xml, Timestamp = DateTime.UtcNow.Ticks});
@@ -44,7 +44,7 @@ public static class TitleUpdateInfoProvider
 
     private static async ValueTask<TitlePatch?> GetCachedAsync(string? productId, bool returnStale = false)
     {
-        await using var db = ThumbnailDb.OpenRead();
+        await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
         var updateInfo = db.GameUpdateInfo
             .AsNoTracking()
             .FirstOrDefault(ui => ui.ProductCode == productId);
@@ -63,7 +63,7 @@ public static class TitleUpdateInfoProvider
 
     public static async Task RefreshGameUpdateInfoAsync(CancellationToken cancellationToken)
     {
-        await using var db = ThumbnailDb.OpenRead();
+        await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
         do
         {
             var productCodeList = await db.Thumbnail.AsNoTracking().Select(t => t.ProductCode).ToListAsync(cancellationToken).ConfigureAwait(false);

--- a/CompatBot/EventHandlers/BotReactionsHandler.cs
+++ b/CompatBot/EventHandlers/BotReactionsHandler.cs
@@ -119,7 +119,7 @@ namespace CompatBot.EventHandlers
 
             if (!string.IsNullOrEmpty(args.Message.Content) && Paws().Matches(args.Message.Content) is MatchCollection mc)
             {
-                await using var db = BotDb.OpenRead();
+                await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
                 var matchedGroups = (from m in mc
                         from Group g in m.Groups
                         where g is { Success: true, Value.Length: > 0 }

--- a/CompatBot/EventHandlers/BotReactionsHandler.cs
+++ b/CompatBot/EventHandlers/BotReactionsHandler.cs
@@ -119,7 +119,7 @@ namespace CompatBot.EventHandlers
 
             if (!string.IsNullOrEmpty(args.Message.Content) && Paws().Matches(args.Message.Content) is MatchCollection mc)
             {
-                await using var db = new BotDb();
+                await using var db = BotDb.OpenRead();
                 var matchedGroups = (from m in mc
                         from Group g in m.Groups
                         where g is { Success: true, Value.Length: > 0 }

--- a/CompatBot/EventHandlers/BotStatusMonitor.cs
+++ b/CompatBot/EventHandlers/BotStatusMonitor.cs
@@ -9,7 +9,7 @@ internal static class BotStatusMonitor
     {
         try
         {
-            await using var db = new BotDb();
+            await using var db = BotDb.OpenRead();
             var status = await db.BotState.FirstOrDefaultAsync(s => s.Key == "bot-status-activity").ConfigureAwait(false);
             var txt = await db.BotState.FirstOrDefaultAsync(s => s.Key == "bot-status-text").ConfigureAwait(false);
             var msg = txt?.Value;

--- a/CompatBot/EventHandlers/BotStatusMonitor.cs
+++ b/CompatBot/EventHandlers/BotStatusMonitor.cs
@@ -9,7 +9,7 @@ internal static class BotStatusMonitor
     {
         try
         {
-            await using var db = BotDb.OpenRead();
+            await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
             var status = await db.BotState.FirstOrDefaultAsync(s => s.Key == "bot-status-activity").ConfigureAwait(false);
             var txt = await db.BotState.FirstOrDefaultAsync(s => s.Key == "bot-status-text").ConfigureAwait(false);
             var msg = txt?.Value;

--- a/CompatBot/EventHandlers/ContentFilterMonitor.cs
+++ b/CompatBot/EventHandlers/ContentFilterMonitor.cs
@@ -5,8 +5,8 @@ namespace CompatBot.EventHandlers;
 
 internal static class ContentFilterMonitor
 {
-    public static Task<bool> OnMessageCreated(DiscordClient c, MessageCreatedEventArgs args) => ContentFilter.IsClean(c, args.Message);
-    public static Task<bool> OnMessageUpdated(DiscordClient c, MessageUpdatedEventArgs args) => ContentFilter.IsClean(c, args.Message);
+    public static async Task<bool> OnMessageCreated(DiscordClient c, MessageCreatedEventArgs args) => await ContentFilter.IsClean(c, args.Message).ConfigureAwait(false);
+    public static async Task<bool> OnMessageUpdated(DiscordClient c, MessageUpdatedEventArgs args) => await ContentFilter.IsClean(c, args.Message).ConfigureAwait(false);
 
     public static async Task OnReaction(DiscordClient c, MessageReactionAddedEventArgs e)
     {

--- a/CompatBot/EventHandlers/Greeter.cs
+++ b/CompatBot/EventHandlers/Greeter.cs
@@ -7,7 +7,7 @@ internal static class Greeter
 {
     public static async Task OnMemberAdded(DiscordClient _, GuildMemberAddedEventArgs args)
     {
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         if (await db.Explanation.FirstOrDefaultAsync(e => e.Keyword == "motd").ConfigureAwait(false) is {Text.Length: >0} explanation)
         {
             var dm = await args.Member.CreateDmChannelAsync().ConfigureAwait(false);

--- a/CompatBot/EventHandlers/Greeter.cs
+++ b/CompatBot/EventHandlers/Greeter.cs
@@ -7,7 +7,7 @@ internal static class Greeter
 {
     public static async Task OnMemberAdded(DiscordClient _, GuildMemberAddedEventArgs args)
     {
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         if (await db.Explanation.FirstOrDefaultAsync(e => e.Keyword == "motd").ConfigureAwait(false) is {Text.Length: >0} explanation)
         {
             var dm = await args.Member.CreateDmChannelAsync().ConfigureAwait(false);

--- a/CompatBot/EventHandlers/IsTheGamePlayableHandler.cs
+++ b/CompatBot/EventHandlers/IsTheGamePlayableHandler.cs
@@ -102,7 +102,7 @@ internal static partial class IsTheGamePlayableHandler
         {
             var requestBuilder = RequestBuilder.Start().SetSearch(gameTitle);
             var searchCompatListTask = Client.GetCompatResultAsync(requestBuilder, Config.Cts.Token);
-            var localList = CompatList.GetLocalCompatResult(requestBuilder);
+            var localList = await CompatList.GetLocalCompatResultAsync(requestBuilder).ConfigureAwait(false);
             var status = await searchCompatListTask.ConfigureAwait(false);
             status = status?.Append(localList);
             if (status is null

--- a/CompatBot/EventHandlers/PostLogHelpHandler.cs
+++ b/CompatBot/EventHandlers/PostLogHelpHandler.cs
@@ -58,7 +58,7 @@ internal static partial class PostLogHelpHandler
 
     public static async Task<Explanation> GetExplanationAsync(string term)
     {
-        await using var db = BotDb.OpenRead();
+        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         var result = await db.Explanation.FirstOrDefaultAsync(e => e.Keyword == term).ConfigureAwait(false);
         return result ?? DefaultExplanation[term];
     }

--- a/CompatBot/EventHandlers/PostLogHelpHandler.cs
+++ b/CompatBot/EventHandlers/PostLogHelpHandler.cs
@@ -58,7 +58,7 @@ internal static partial class PostLogHelpHandler
 
     public static async Task<Explanation> GetExplanationAsync(string term)
     {
-        await using var db = new BotDb();
+        await using var db = BotDb.OpenRead();
         var result = await db.Explanation.FirstOrDefaultAsync(e => e.Keyword == term).ConfigureAwait(false);
         return result ?? DefaultExplanation[term];
     }

--- a/CompatBot/EventHandlers/ProductCodeLookup.cs
+++ b/CompatBot/EventHandlers/ProductCodeLookup.cs
@@ -112,7 +112,10 @@ internal static partial class ProductCodeLookup
     public static async ValueTask<(DiscordEmbedBuilder embedBuilder, CompatResult? compatResult)> LookupGameInfoWithEmbedAsync(this DiscordClient client, string? code, string? gameTitle = null, bool forLog = false, string? category = null)
     {
         if (string.IsNullOrEmpty(code))
-            return (TitleInfo.Unknown.AsEmbed(code, gameTitle, forLog), null);
+            return (
+                await TitleInfo.Unknown.AsEmbedAsync(code, gameTitle, forLog).ConfigureAwait(false), 
+                null
+            );
 
         string? thumbnailUrl = null;
         CompatResult? result = null;
@@ -120,15 +123,23 @@ internal static partial class ProductCodeLookup
         {
             result = await CompatClient.GetCompatResultAsync(RequestBuilder.Start().SetSearch(code), Config.Cts.Token).ConfigureAwait(false);
             if (result?.ReturnCode == -2)
-                return (TitleInfo.Maintenance.AsEmbed(code), result);
+                return (
+                    await TitleInfo.Maintenance.AsEmbedAsync(code).ConfigureAwait(false),
+                    result
+                );
 
             if (result?.ReturnCode == -1)
-                return (TitleInfo.CommunicationError.AsEmbed(code), result);
+                return (
+                    await TitleInfo.CommunicationError.AsEmbedAsync(code).ConfigureAwait(false),
+                    result
+                );
 
             thumbnailUrl = await client.GetThumbnailUrlAsync(code).ConfigureAwait(false);
-
             if (result?.Results != null && result.Results.TryGetValue(code, out var info))
-                return (info.AsEmbed(code, gameTitle, forLog, thumbnailUrl), result);
+                return (
+                    await info.AsEmbedAsync(code, gameTitle, forLog, thumbnailUrl).ConfigureAwait(false),
+                    result
+                );
 
             gameTitle ??= await ThumbnailProvider.GetTitleNameAsync(code, Config.Cts.Token).ConfigureAwait(false);
             if (category == "1P")
@@ -140,7 +151,10 @@ internal static partial class ProductCodeLookup
                     Pr = 4802,
                     Status = "Playable",
                 };
-                return (ti.AsEmbed(code, gameTitle, forLog, thumbnailUrl), result);
+                return (
+                    await ti.AsEmbedAsync(code, gameTitle, forLog, thumbnailUrl).ConfigureAwait(false),
+                    result
+                );
             }
             if (category is "2P" or "2G" or "2D" or "PP" or "PE" or "MN")
             {
@@ -148,14 +162,23 @@ internal static partial class ProductCodeLookup
                 {
                     Status = "Nothing"
                 };
-                return (ti.AsEmbed(code, gameTitle, forLog, thumbnailUrl), result);
+                return (
+                    await ti.AsEmbedAsync(code, gameTitle, forLog, thumbnailUrl).ConfigureAwait(false),
+                    result
+                );
             }
-            return (TitleInfo.Unknown.AsEmbed(code, gameTitle, forLog, thumbnailUrl), result);
+            return (
+                await TitleInfo.Unknown.AsEmbedAsync(code, gameTitle, forLog, thumbnailUrl).ConfigureAwait(false),
+                result
+            );
         }
         catch (Exception e)
         {
             Config.Log.Warn(e, $"Couldn't get compat result for {code}");
-            return (TitleInfo.CommunicationError.AsEmbed(code, gameTitle, forLog, thumbnailUrl), result);
+            return (
+                await TitleInfo.CommunicationError.AsEmbedAsync(code, gameTitle, forLog, thumbnailUrl).ConfigureAwait(false),
+                result
+            );
         }
     }
 }

--- a/CompatBot/EventHandlers/ThumbnailCacheMonitor.cs
+++ b/CompatBot/EventHandlers/ThumbnailCacheMonitor.cs
@@ -15,7 +15,7 @@ internal static class ThumbnailCacheMonitor
         if (!args.Message.Attachments.Any())
             return;
 
-        await using var db = ThumbnailDb.OpenRead();
+        await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
         var thumb = db.Thumbnail.FirstOrDefault(i => i.ContentId == args.Message.Content);
         if (thumb is { EmbeddableUrl: { Length: > 0 } url } && args.Message.Attachments.Any(a => a.Url == url))
         {

--- a/CompatBot/EventHandlers/ThumbnailCacheMonitor.cs
+++ b/CompatBot/EventHandlers/ThumbnailCacheMonitor.cs
@@ -15,7 +15,7 @@ internal static class ThumbnailCacheMonitor
         if (!args.Message.Attachments.Any())
             return;
 
-        await using var db = new ThumbnailDb();
+        await using var db = ThumbnailDb.OpenRead();
         var thumb = db.Thumbnail.FirstOrDefault(i => i.ContentId == args.Message.Content);
         if (thumb is { EmbeddableUrl: { Length: > 0 } url } && args.Message.Attachments.Any(a => a.Url == url))
         {

--- a/CompatBot/EventHandlers/UsernameValidationMonitor.cs
+++ b/CompatBot/EventHandlers/UsernameValidationMonitor.cs
@@ -19,7 +19,7 @@ public static class UsernameValidationMonitor
             if (guild.Permissions?.HasFlag(DiscordPermission.ChangeNickname) is false)
                 return;
 
-            await using var db = BotDb.OpenRead();
+            await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
             var forcedNickname = await db.ForcedNicknames.AsNoTracking().FirstOrDefaultAsync(x => x.UserId == guildMember.Id && x.GuildId == guildMember.Guild.Id).ConfigureAwait(false);
             if (forcedNickname is null)
                 return;
@@ -54,7 +54,7 @@ public static class UsernameValidationMonitor
                         if (guild.Permissions?.HasFlag(DiscordPermission.ChangeNickname) is false)
                             continue;
 
-                        await using var db = BotDb.OpenRead();
+                        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
                         var forcedNicknames = await db.ForcedNicknames
                             .Where(mem => mem.GuildId == guild.Id)
                             .ToListAsync()

--- a/CompatBot/EventHandlers/UsernameValidationMonitor.cs
+++ b/CompatBot/EventHandlers/UsernameValidationMonitor.cs
@@ -19,7 +19,7 @@ public static class UsernameValidationMonitor
             if (guild.Permissions?.HasFlag(DiscordPermission.ChangeNickname) is false)
                 return;
 
-            await using var db = new BotDb();
+            await using var db = BotDb.OpenRead();
             var forcedNickname = await db.ForcedNicknames.AsNoTracking().FirstOrDefaultAsync(x => x.UserId == guildMember.Id && x.GuildId == guildMember.Guild.Id).ConfigureAwait(false);
             if (forcedNickname is null)
                 return;
@@ -54,7 +54,7 @@ public static class UsernameValidationMonitor
                         if (guild.Permissions?.HasFlag(DiscordPermission.ChangeNickname) is false)
                             continue;
 
-                        await using var db = new BotDb();
+                        await using var db = BotDb.OpenRead();
                         var forcedNicknames = await db.ForcedNicknames
                             .Where(mem => mem.GuildId == guild.Id)
                             .ToListAsync()

--- a/CompatBot/EventHandlers/UsernameZalgoMonitor.cs
+++ b/CompatBot/EventHandlers/UsernameZalgoMonitor.cs
@@ -206,7 +206,7 @@ public static class UsernameZalgoMonitor
     {
         var hash = userId.GetHashCode();
         var rng = new Random(hash);
-        using var db = new ThumbnailDb();
+        using var db = ThumbnailDb.OpenRead();
         var count = db.NamePool.Count();
         var name = db.NamePool.Skip(rng.Next(count)).First().Name;
         return name + Config.RenameNameSuffix;

--- a/CompatBot/Program.cs
+++ b/CompatBot/Program.cs
@@ -192,7 +192,7 @@ internal static class Program
                         var msg = new StringBuilder($"Bot admin id{(owners.Count == 1 ? "": "s")}:");
                         if (owners.Count > 1)
                             msg.AppendLine();
-                        await using var db = new BotDb();
+                        await using var db = BotDb.OpenRead();
                         foreach (var owner in owners)
                         {
                             msg.AppendLine($"\t{owner.Id} ({owner.Username ?? "???"}#{owner.Discriminator ?? "????"})");
@@ -310,7 +310,7 @@ internal static class Program
 
             ulong? channelId = null;
             string? restartMsg = null;
-            await using (var db = new BotDb())
+            await using (var db = BotDb.OpenRead())
             {
                 var chState = db.BotState.FirstOrDefault(k => k.Key == "bot-restart-channel");
                 if (chState != null)

--- a/CompatBot/Program.cs
+++ b/CompatBot/Program.cs
@@ -192,7 +192,7 @@ internal static class Program
                         var msg = new StringBuilder($"Bot admin id{(owners.Count == 1 ? "": "s")}:");
                         if (owners.Count > 1)
                             msg.AppendLine();
-                        await using var db = BotDb.OpenRead();
+                        await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
                         foreach (var owner in owners)
                         {
                             msg.AppendLine($"\t{owner.Id} ({owner.Username ?? "???"}#{owner.Discriminator ?? "????"})");
@@ -310,7 +310,7 @@ internal static class Program
 
             ulong? channelId = null;
             string? restartMsg = null;
-            await using (var db = BotDb.OpenRead())
+            await using (var db = await BotDb.OpenReadAsync().ConfigureAwait(false))
             {
                 var chState = db.BotState.FirstOrDefault(k => k.Key == "bot-restart-channel");
                 if (chState != null)

--- a/CompatBot/ThumbScrapper/GameTdbScraper.cs
+++ b/CompatBot/ThumbScrapper/GameTdbScraper.cs
@@ -71,7 +71,7 @@ internal static partial class GameTdbScraper
         var container = Path.GetFileName(TitleDownloadLink.AbsolutePath);
         try
         {
-            if (ScrapeStateProvider.IsFresh(container))
+            if (await ScrapeStateProvider.IsFreshAsync(container).ConfigureAwait(false))
                 return;
 
             Config.Log.Debug("Scraping GameTDB for game titles…");
@@ -91,7 +91,7 @@ internal static partial class GameTdbScraper
             if (!DateTime.TryParseExact(version, "yyyyMMddHHmmss", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal, out var timestamp))
                 return;
 
-            if (ScrapeStateProvider.IsFresh("PS3TDB", timestamp))
+            if (await ScrapeStateProvider.IsFreshAsync("PS3TDB", timestamp).ConfigureAwait(false))
             {
                 await ScrapeStateProvider.SetLastRunTimestampAsync("PS3TDB").ConfigureAwait(false);
                 return;
@@ -113,7 +113,7 @@ internal static partial class GameTdbScraper
                 if (string.IsNullOrEmpty(title))
                     continue;
 
-                await using var db = ThumbnailDb.OpenRead();
+                await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
                 var item = await db.Thumbnail.FirstOrDefaultAsync(t => t.ProductCode == productId, cancellationToken).ConfigureAwait(false);
                 if (item is null)
                 {

--- a/CompatBot/ThumbScrapper/GameTdbScraper.cs
+++ b/CompatBot/ThumbScrapper/GameTdbScraper.cs
@@ -113,7 +113,7 @@ internal static partial class GameTdbScraper
                 if (string.IsNullOrEmpty(title))
                     continue;
 
-                await using var db = new ThumbnailDb();
+                await using var db = ThumbnailDb.OpenRead();
                 var item = await db.Thumbnail.FirstOrDefaultAsync(t => t.ProductCode == productId, cancellationToken).ConfigureAwait(false);
                 if (item is null)
                 {

--- a/CompatBot/ThumbScrapper/PsnScraper.cs
+++ b/CompatBot/ThumbScrapper/PsnScraper.cs
@@ -23,6 +23,7 @@ internal sealed partial class PsnScraper
     private static DateTime storeRefreshTimestamp = DateTime.MinValue;
     private static readonly SemaphoreSlim QueueLimiter = new(32, 32);
 
+    [Obsolete]
     public static async Task RunAsync(CancellationToken cancellationToken)
     {
         do
@@ -292,7 +293,7 @@ internal sealed partial class PsnScraper
 
     private static bool NeedLookup(string contentId)
     {
-        using var db = new ThumbnailDb();
+        using var db = ThumbnailDb.OpenRead();
         if (db.Thumbnail.FirstOrDefault(t => t.ContentId == contentId) is Thumbnail thumbnail)
             if (!string.IsNullOrEmpty(thumbnail.Url))
                 if (ScrapeStateProvider.IsFresh(new DateTime(thumbnail.Timestamp, DateTimeKind.Utc)))
@@ -350,7 +351,7 @@ internal sealed partial class PsnScraper
             return;
 
         name = string.IsNullOrEmpty(name) ? null : name;
-        await using var db = new ThumbnailDb();
+        await using var db = ThumbnailDb.OpenRead();
         var savedItem = db.Thumbnail.FirstOrDefault(t => t.ProductCode == productCode);
         if (savedItem == null)
         {

--- a/CompatBot/ThumbScrapper/PsnScraper.cs
+++ b/CompatBot/ThumbScrapper/PsnScraper.cs
@@ -141,7 +141,7 @@ internal sealed partial class PsnScraper
             if (cancellationToken.IsCancellationRequested)
                 break;
 
-            if (ScrapeStateProvider.IsFresh(locale))
+            if (await ScrapeStateProvider.IsFreshAsync(locale).ConfigureAwait(false))
             {
                 //Config.Log.Debug($"Cache for {locale} PSN is fresh, skipping");
                 continue;
@@ -181,7 +181,7 @@ internal sealed partial class PsnScraper
                 if (cancellationToken.IsCancellationRequested)
                     return;
 
-                if (ScrapeStateProvider.IsFresh(locale, containerId))
+                if (await ScrapeStateProvider.IsFreshAsync(locale, containerId).ConfigureAwait(false))
                 {
                     //Config.Log.Debug($"\tCache for {locale} container {containerId} is fresh, skipping");
                     continue;
@@ -219,7 +219,7 @@ internal sealed partial class PsnScraper
                         var pages = (int)Math.Ceiling((double)total / take);
                         if (pages > 1)
                             Config.Log.Debug($"\t\tPage {start / take + 1} of {pages}");
-                        returned = container.Data?.Relationships?.Children?.Data?.Count(i => i.Type == "game" || i.Type == "legacy-sku") ?? 0;
+                        returned = container.Data?.Relationships?.Children?.Data?.Count(i => i.Type is "game" or "legacy-sku") ?? 0;
                         // included contains full data already, so it's wise to get it first
                         await ProcessIncludedGamesAsync(locale, container, cancellationToken).ConfigureAwait(false);
 
@@ -231,9 +231,9 @@ internal sealed partial class PsnScraper
                                 if (cancellationToken.IsCancellationRequested)
                                     return;
 
-                                if (item.Type == "game")
+                                if (item.Type is "game")
                                 {
-                                    if (!NeedLookup(item.Id))
+                                    if (!await NeedLookupAsync(item.Id).ConfigureAwait(false))
                                         continue;
                                 }
                                 else if (item.Type != "legacy-sku")
@@ -291,9 +291,9 @@ internal sealed partial class PsnScraper
         return result;
     }
 
-    private static bool NeedLookup(string contentId)
+    private static async ValueTask<bool> NeedLookupAsync(string contentId)
     {
-        using var db = ThumbnailDb.OpenRead();
+        await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
         if (db.Thumbnail.FirstOrDefault(t => t.ContentId == contentId) is Thumbnail thumbnail)
             if (!string.IsNullOrEmpty(thumbnail.Url))
                 if (ScrapeStateProvider.IsFresh(new DateTime(thumbnail.Timestamp, DateTimeKind.Utc)))
@@ -327,8 +327,10 @@ internal sealed partial class PsnScraper
                             .Concat(item.Attributes?.Entitlements ?? Enumerable.Empty<GameSkuRelation>())
                             .Select(sku => sku.Id)
                             .Distinct()
-                            .Where(id => ProductCodeLookup.Pattern().IsMatch(id) && NeedLookup(id))
-                            .ToList();
+                            .ToAsyncEnumerable()
+                            .WhereAwait(async id => ProductCodeLookup.Pattern().IsMatch(id)
+                                                    && await NeedLookupAsync(id).ConfigureAwait(false)
+                            ).ToList();
                         foreach (var relatedSku in relatedSkus)
                         {
                             var relatedContainer = await Client.ResolveContentAsync(locale, relatedSku, 1, cancellationToken).ConfigureAwait(false);
@@ -351,7 +353,7 @@ internal sealed partial class PsnScraper
             return;
 
         name = string.IsNullOrEmpty(name) ? null : name;
-        await using var db = ThumbnailDb.OpenRead();
+        await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
         var savedItem = db.Thumbnail.FirstOrDefault(t => t.ProductCode == productCode);
         if (savedItem == null)
         {

--- a/CompatBot/Utils/ResultFormatters/TitleInfoFormatter.cs
+++ b/CompatBot/Utils/ResultFormatters/TitleInfoFormatter.cs
@@ -62,7 +62,7 @@ internal static class TitleInfoFormatter
         var productCodePart = string.IsNullOrWhiteSpace(titleId) ? "" : $"[{titleId}] ";
         if (!StatusColors.TryGetValue(info.Status, out _) && !string.IsNullOrEmpty(titleId))
         {
-            using var db = new ThumbnailDb();
+            using var db = ThumbnailDb.OpenRead();
             var thumb = db.Thumbnail.FirstOrDefault(t => t.ProductCode == titleId);
             if (thumb?.CompatibilityStatus != null)
             {

--- a/CompatBot/Utils/ResultFormatters/TitleInfoFormatter.cs
+++ b/CompatBot/Utils/ResultFormatters/TitleInfoFormatter.cs
@@ -54,7 +54,13 @@ internal static class TitleInfoFormatter
         return $"Product code {titleId} was not found in compatibility database";
     }
 
-    public static DiscordEmbedBuilder AsEmbed(this TitleInfo info, string? titleId, string? gameTitle = null, bool forLog = false, string? thumbnailUrl = null)
+    public static async ValueTask<DiscordEmbedBuilder> AsEmbedAsync(
+        this TitleInfo info,
+        string? titleId,
+        string? gameTitle = null,
+        bool forLog = false,
+        string? thumbnailUrl = null
+    )
     {
         if (string.IsNullOrWhiteSpace(gameTitle))
             gameTitle = null;
@@ -62,7 +68,7 @@ internal static class TitleInfoFormatter
         var productCodePart = string.IsNullOrWhiteSpace(titleId) ? "" : $"[{titleId}] ";
         if (!StatusColors.TryGetValue(info.Status, out _) && !string.IsNullOrEmpty(titleId))
         {
-            using var db = ThumbnailDb.OpenRead();
+            await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
             var thumb = db.Thumbnail.FirstOrDefault(t => t.ProductCode == titleId);
             if (thumb?.CompatibilityStatus != null)
             {
@@ -78,7 +84,7 @@ internal static class TitleInfoFormatter
         if (info.Status is string status && StatusColors.TryGetValue(status, out var color))
         {
             // apparently there's no formatting in the footer, but you need to escape everything in description; ugh
-            var onlineOnlyPart = info.Network == 1 ? " 🌐" : "";
+            var onlineOnlyPart = info.Network is 1 ? " 🌐" : "";
             var desc = $"{info.Status} since {info.ToUpdated() ?? "forever"}";
             if (info.Pr > 0)
                 desc += $" (PR {info.ToPrString()})";
@@ -141,6 +147,6 @@ internal static class TitleInfoFormatter
     public static string AsString(this KeyValuePair<string, TitleInfo> resultInfo)
         => resultInfo.Value.AsString(resultInfo.Key);
 
-    public static DiscordEmbed AsEmbed(this KeyValuePair<string, TitleInfo> resultInfo)
-        => resultInfo.Value.AsEmbed(resultInfo.Key);
+    public static ValueTask<DiscordEmbedBuilder> AsEmbedAsync(this KeyValuePair<string, TitleInfo> resultInfo)
+        => resultInfo.Value.AsEmbedAsync(resultInfo.Key);
 }

--- a/Tests/StringUtilTests.cs
+++ b/Tests/StringUtilTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using CompatBot.EventHandlers;
 using CompatBot.Utils;
 using CompatBot.Utils.Extensions;
@@ -51,9 +52,9 @@ public class StringUtilTests
     }
 
     [TestCase("jò̵͗s̷̑͠ẻ̵͝p̸̆̂h̸͐̿", "joseph")]
-    public void StripZalgoTest(string input, string expected)
+    public async Task StripZalgoTest(string input, string expected)
     {
-        var stripped = UsernameZalgoMonitor.StripZalgo(input, null, 0ul);
+        var stripped = await UsernameZalgoMonitor.StripZalgoAsync(input, null, 0ul).ConfigureAwait(false);
         Assert.That(stripped, Is.EqualTo(expected));
     }
 

--- a/Tests/ZalgoTests.cs
+++ b/Tests/ZalgoTests.cs
@@ -33,7 +33,7 @@ public class ZalgoTests
         foreach (var line in names)
         {
             var user = UserInfo.Parse(line);
-            var isZalgo = UsernameZalgoMonitor.NeedsRename(user.DisplayName);
+            var isZalgo = await UsernameZalgoMonitor.NeedsRenameAsync(user.DisplayName).ConfigureAwait(false);
             if (isZalgo)
                 await w.WriteLineAsync(user.DisplayName).ConfigureAwait(false);
         }
@@ -82,9 +82,10 @@ public class ZalgoTests
     [TestCase("͔", true, "Combining marks")]
     [TestCase("҉҉҉҉", true, "Combining sign")]
     [TestCase("᲼᲼᲼᲼᲼᲼᲼᲼᲼ ", true, "Private block")]
-    public void ZalgoDetectionTest(string name, bool isBad, string? comment = null)
+    public async Task ZalgoDetectionTest(string name, bool isBad, string? comment = null)
     {
-        Assert.That(UsernameZalgoMonitor.NeedsRename(name), Is.EqualTo(isBad), comment);
+        var result = await UsernameZalgoMonitor.NeedsRenameAsync(name).ConfigureAwait(false);
+        Assert.That(result, Is.EqualTo(isBad), comment);
     }
 }
 


### PR DESCRIPTION
Apparently this happens when read transaction got started as read-only, but then failed to be promoted to write because there was another write in the meantime.

Tracking issue on dotnet/efcore#29514.

So, try to separate reads/writes with a read/write lock per database.
As part of this effort there's been a lot of async code clean up, with some logic and resource management fixes, as well as further switch to `ValueTask` wherever possible.