### PR TITLE
Upgrading dependencies

### DIFF
--- a/Clients/CirrusCiClient/CirrusCiClient.csproj
+++ b/Clients/CirrusCiClient/CirrusCiClient.csproj
@@ -9,9 +9,9 @@
     <ProjectReference Include="..\CompatApiClient\CompatApiClient.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.3" />
-    <PackageReference Include="StrawberryShake.Server" Version="15.1.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.5" />
+    <PackageReference Include="StrawberryShake.Server" Version="15.1.4" />
   </ItemGroup>
 </Project>

--- a/Clients/CompatApiClient/CompatApiClient.csproj
+++ b/Clients/CompatApiClient/CompatApiClient.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.5" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageReference Include="NLog" Version="5.4.0" />
   </ItemGroup>

--- a/Clients/GithubClient/GithubClient.csproj
+++ b/Clients/GithubClient/GithubClient.csproj
@@ -5,7 +5,7 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.5" />
     <PackageReference Include="Octokit" Version="14.0.0" />
     <PackageReference Include="SharpCompress" Version="0.39.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />

--- a/Clients/IrdLibraryClient/IrdLibraryClient.csproj
+++ b/Clients/IrdLibraryClient/IrdLibraryClient.csproj
@@ -5,9 +5,9 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LTRData.DiscUtils.OpticalDisk" Version="1.0.54" />
+    <PackageReference Include="LTRData.DiscUtils.OpticalDisk" Version="1.0.55" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
-    <PackageReference Include="System.IO.Hashing" Version="9.0.3" />
+    <PackageReference Include="System.IO.Hashing" Version="9.0.5" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\CompatApiClient\CompatApiClient.csproj" />

--- a/Clients/PsnClient/PsnClient.csproj
+++ b/Clients/PsnClient/PsnClient.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.WebApi.Client" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.5" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/CompatBot/Commands/DevOnly.cs
+++ b/CompatBot/Commands/DevOnly.cs
@@ -51,7 +51,7 @@ internal sealed class DevOnly
     {
         var builder = new DiscordMessageBuilder()
             .WithContent("Regular button vs emoji button")
-            .AddComponents(
+            .AddActionRowComponent(
                 new DiscordButtonComponent(DiscordButtonStyle.Primary, "pt", "✅ Regular"),
                 new DiscordButtonComponent(DiscordButtonStyle.Primary, "pe", "Emoji", emoji: new(DiscordEmoji.FromUnicode("✅")))
             );

--- a/CompatBot/Commands/Explain.cs
+++ b/CompatBot/Commands/Explain.cs
@@ -116,13 +116,11 @@ internal static class Explain
                 .AsEphemeral()
                 .WithCustomId($"modal:warn:{Guid.NewGuid():n}")
                 .WithTitle("New explanation")
-                .AddComponents(
-                    new DiscordTextInputComponent(
-                        label,
-                        "explanation", 
-                        style: DiscordTextInputStyle.Paragraph
-                    )
-                );
+                .AddTextInputComponent(new(
+                    label,
+                    "explanation", 
+                    style: DiscordTextInputStyle.Paragraph
+                ));
             await ctx.RespondWithModalAsync(modal).ConfigureAwait(false);
 
             InteractivityResult<ModalSubmittedEventArgs> modalResult;
@@ -251,14 +249,12 @@ internal static class Explain
             .AsEphemeral()
             .WithCustomId($"modal:warn:{Guid.NewGuid():n}")
             .WithTitle("Updated explanation")
-            .AddComponents(
-                new DiscordTextInputComponent(
-                    label,
-                    "explanation",
-                    value: item.Text,
-                    style: DiscordTextInputStyle.Paragraph
-                )
-            );
+            .AddTextInputComponent(new(
+                label,
+                "explanation",
+                value: item.Text,
+                style: DiscordTextInputStyle.Paragraph
+            ));
         await ctx.RespondWithModalAsync(modal).ConfigureAwait(false);
 
         InteractivityResult<ModalSubmittedEventArgs> modalResult;

--- a/CompatBot/Commands/ForcedNicknames.cs
+++ b/CompatBot/Commands/ForcedNicknames.cs
@@ -30,16 +30,14 @@ internal static class ForcedNicknames
             .AsEphemeral()
             .WithCustomId($"modal:nickname:{Guid.NewGuid():n}")
             .WithTitle("Enforcing Rule 7")
-            .AddComponents(
-                new DiscordTextInputComponent(
-                    "New nickname",
-                    "nickname",
-                    suggestedName,
-                    suggestedName,
-                    min_length: 2,
-                    max_length: 32
-                )
-            );
+            .AddTextInputComponent(new(
+                "New nickname",
+                "nickname",
+                suggestedName,
+                suggestedName,
+                min_length: 2,
+                max_length: 32
+            ));
         await ctx.RespondWithModalAsync(modal).ConfigureAwait(false);
 
         string resultMsg;

--- a/CompatBot/Commands/MessageMenuCommands.cs
+++ b/CompatBot/Commands/MessageMenuCommands.cs
@@ -32,9 +32,8 @@ internal static class MessageMenuCommands
         var placeholder = StatsStorage.GetExplainStats().FirstOrDefault().name ?? "rule 1";
         var modal = new DiscordInteractionResponseBuilder()
             .WithTitle("Explain Prompt")
-            .AddComponents(new DiscordTextInputComponent("Term to explain", "term", placeholder, min_length: 1))
+            .AddTextInputComponent(new("Term to explain", "term", placeholder, min_length: 1))
             .WithCustomId($"modal:explain:{Guid.NewGuid():n}");
-
         await ctx.RespondWithModalAsync(modal).ConfigureAwait(false);
 
         InteractivityResult<ModalSubmittedEventArgs> modalResult;
@@ -80,16 +79,14 @@ internal static class MessageMenuCommands
                 .AsEphemeral()
                 .WithCustomId($"modal:report:{Guid.NewGuid():n}")
                 .WithTitle("Message Report")
-                .AddComponents(
-                    new DiscordTextInputComponent(
-                        "Comment",
-                        "comment",
-                        "Describe why you report this message",
-                        required: false,
-                        style: DiscordTextInputStyle.Paragraph,
-                        max_length: EmbedPager.MaxFieldLength
-                    )
-                );
+                .AddTextInputComponent(new(
+                    "Comment",
+                    "comment",
+                    "Describe why you report this message",
+                    required: false,
+                    style: DiscordTextInputStyle.Paragraph,
+                    max_length: EmbedPager.MaxFieldLength
+                ));
             await ctx.RespondWithModalAsync(modal).ConfigureAwait(false);
             var modalResult = await interactivity.WaitForModalAsync(modal.CustomId, ctx.User).ConfigureAwait(false);
             if (modalResult.TimedOut)

--- a/CompatBot/Commands/Warnings.ContextMenus.cs
+++ b/CompatBot/Commands/Warnings.ContextMenus.cs
@@ -34,14 +34,12 @@ internal static class WarningsContextMenus
             .AsEphemeral()
             .WithCustomId($"modal:warn:{Guid.NewGuid():n}")
             .WithTitle("Issue new warning")
-            .AddComponents(
-                new DiscordTextInputComponent(
-                    "Warning reason",
-                    "warning",
-                    "Rule #2",
-                    min_length: 2
-                )
-            );
+            .AddTextInputComponent(new(
+                "Warning reason",
+                "warning",
+                "Rule #2",
+                min_length: 2
+            ));
         await ctx.RespondWithModalAsync(modal).ConfigureAwait(false);
 
         try

--- a/CompatBot/CompatBot.csproj
+++ b/CompatBot/CompatBot.csproj
@@ -42,9 +42,9 @@
   <ItemGroup>
     <PackageReference Include="Blurhash.ImageSharp" Version="4.0.0" />
     <PackageReference Include="CommunityToolkit.HighPerformance" Version="8.4.0" />
-    <PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02478" />
-    <PackageReference Include="DSharpPlus.Commands" Version="5.0.0-nightly-02478" />
-    <PackageReference Include="DSharpPlus.Interactivity" Version="5.0.0-nightly-02478" />
+    <PackageReference Include="DSharpPlus" Version="5.0.0-nightly-02506" />
+    <PackageReference Include="DSharpPlus.Commands" Version="5.0.0-nightly-02506" />
+    <PackageReference Include="DSharpPlus.Interactivity" Version="5.0.0-nightly-02506" />
     <PackageReference Include="DSharpPlus.Natives.Zstd" Version="1.5.7.21" />
     <PackageReference Include="Google.Apis.Drive.v3" Version="1.69.0.3778" />
     <PackageReference Include="MathParser.org-mXparser" Version="6.1.0" />

--- a/CompatBot/CompatBot.csproj
+++ b/CompatBot/CompatBot.csproj
@@ -46,21 +46,21 @@
     <PackageReference Include="DSharpPlus.Commands" Version="5.0.0-nightly-02478" />
     <PackageReference Include="DSharpPlus.Interactivity" Version="5.0.0-nightly-02478" />
     <PackageReference Include="DSharpPlus.Natives.Zstd" Version="1.5.7.21" />
-    <PackageReference Include="Google.Apis.Drive.v3" Version="1.69.0.3703" />
+    <PackageReference Include="Google.Apis.Drive.v3" Version="1.69.0.3778" />
     <PackageReference Include="MathParser.org-mXparser" Version="6.1.0" />
     <PackageReference Include="MegaApiClient" Version="1.10.4" />
     <PackageReference Include="Microsoft.ApplicationInsights.DependencyCollector" Version="2.23.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.23.0" />
     <PackageReference Include="Microsoft.Azure.CognitiveServices.Vision.ComputerVision" Version="7.0.1" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.3">
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="9.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.3" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.EnvironmentVariables" Version="9.0.5" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.UserSecrets" Version="9.0.5" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="3.0.1" />
     <PackageReference Include="Microsoft.TeamFoundationServer.Client" Version="19.225.1" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.21.2" />
@@ -70,7 +70,7 @@
     <PackageReference Include="NLog.Extensions.Logging" Version="5.4.0" />
     <PackageReference Include="NReco.Text.AhoCorasickDoubleArrayTrie" Version="1.1.1" />
     <PackageReference Include="SharpCompress" Version="0.39.0" />
-    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.5" />
+    <PackageReference Include="SixLabors.ImageSharp.Drawing" Version="2.1.6" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>
   <ItemGroup>

--- a/CompatBot/EventHandlers/ProductCodeLookup.cs
+++ b/CompatBot/EventHandlers/ProductCodeLookup.cs
@@ -58,7 +58,7 @@ internal static partial class ProductCodeLookup
                     var messageBuilder = new DiscordMessageBuilder().AddEmbed(result.builder);
                     //todo: pass author from context and update OnCheckUpdatesButtonClick in psn check updates
                     if (message is {Author: not null} && channel.IsSpamChannel())
-                        messageBuilder.AddComponents(
+                        messageBuilder.AddActionRowComponent(
                             new DiscordButtonComponent(
                                 DiscordButtonStyle.Secondary,
                                 $"{GlobalButtonHandler.ReplaceWithUpdatesPrefix}{result.code}",

--- a/SourceGenerators/SourceGenerators.csproj
+++ b/SourceGenerators/SourceGenerators.csproj
@@ -10,7 +10,7 @@
 
     <ItemGroup>
         <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" PrivateAssets="all" />
     </ItemGroup>
 
 </Project>

--- a/SourceGenerators/SourceGenerators.csproj
+++ b/SourceGenerators/SourceGenerators.csproj
@@ -9,8 +9,8 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="3.11.0" PrivateAssets="all" />
-        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.Analyzers" Version="4.14.0" PrivateAssets="all" />
+        <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
     </ItemGroup>
 
 </Project>

--- a/Tests/Tests.csproj
+++ b/Tests/Tests.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="DuoVia.FuzzyStrings" Version="2.1.0" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.0.5" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageReference Include="NUnit" Version="4.3.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="5.0.0">


### PR DESCRIPTION
There are two breaking changes in this one:
* Roslyn code generators require new incremental interface to be implemented
* D#+ broke how interactive components are added in message builders to accommodate v2 changes