### PR TITLE
add a check for 700, 900 and 10 series

### DIFF
--- a/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.GeneralNotesSection.cs
+++ b/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.GeneralNotesSection.cs
@@ -305,6 +305,8 @@ internal static partial class LogParserResult
                                 && items["renderer"] == "Vulkan")
                                 notes.Add("ℹ️ 400 series nVidia drivers can cause screen freezes, please update RPCS3");
                         }
+                        if (gpuInfo.Contains("GTX 10") || gpuInfo.Contains("GTX 9") || gpuInfo.Contains("GTX 7"))
+                            notes.Add("ℹ️ Your nVidia GPU no longer receives driver updates.");
                     }
                     else if (IsAmd(gpuInfo) && items["os_type"] is "Windows")
                     {

--- a/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.cs
+++ b/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.cs
@@ -53,8 +53,8 @@ internal static partial class LogParserResult
     private static readonly Version NvidiaTextureMemoryBugMinVersion = new(526, 0);
     private static readonly Version NvidiaTextureMemoryBugMaxVersion = new(526, 99);
     
-    private static readonly Version NvidiaRecommendedWindowsDriverVersion = new(512, 16);
-    private static readonly Version NvidiaRecommendedLinuxDriverVersion = new(515, 57);
+    private static readonly Version NvidiaRecommendedWindowsDriverVersion = new(580, 0);
+    private static readonly Version NvidiaRecommendedLinuxDriverVersion = new(580, 0);
     private static readonly Version AmdRecommendedWindowsDriverVersion = new(24, 2, 1);
     private static readonly Version IntelRecommendedWindowsDriverVersion = new(0, 101, 1660);
 


### PR DESCRIPTION
Since nvidia is dropping support for 700, 900 and 10 series GPUs with 580 drivers, it could be worth adding a note to user log about their GPU no longer having drivers updates