### PR TITLE
Fix autocomplete providers for some slash commands

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,14 +3,14 @@
   "isRoot": true,
   "tools": {
     "strawberryshake.tools": {
-      "version": "15.0.3",
+      "version": "15.1.8",
       "commands": [
         "dotnet-graphql"
       ],
       "rollForward": false
     },
     "dotnet-ef": {
-      "version": "9.0.1",
+      "version": "9.0.8",
       "commands": [
         "dotnet-ef"
       ],

--- a/CompatBot/Commands/AutoCompleteProviders/ContentFilterAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/ContentFilterAutoCompleteProvider.cs
@@ -13,6 +13,7 @@ public class ContentFilterAutoCompleteProvider: IAutoCompleteProvider
             return [new($"{Config.Reactions.Denied} You are not authorized to use this command.", -1)];
         
         await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
+        db.WithNoCase();
         IEnumerable<(int id, string trigger)> result;
         if (context.UserInput is not {Length: >0} prefix)
             result = db.Piracystring

--- a/CompatBot/Commands/AutoCompleteProviders/ExplainAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/ExplainAutoCompleteProvider.cs
@@ -10,6 +10,7 @@ public class ExplainAutoCompleteProvider: IAutoCompleteProvider
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
     {
         await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
+        db.WithNoCase();
         IEnumerable<string> result;
         if (context.UserInput is not { Length: > 0 } prefix)
         {

--- a/CompatBot/Commands/AutoCompleteProviders/InviteAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/InviteAutoCompleteProvider.cs
@@ -13,6 +13,7 @@ public class InviteAutoCompleteProvider: IAutoCompleteProvider
             return [new($"{Config.Reactions.Denied} You are not authorized to use this command.", -1)];
         
         await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
+        db.WithNoCase();
         IQueryable<WhitelistedInvite> result;
         if (context.UserInput is not { Length: > 0 } input)
             result = db.WhitelistedInvites

--- a/CompatBot/Commands/AutoCompleteProviders/ProductCodeAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/ProductCodeAutoCompleteProvider.cs
@@ -10,6 +10,7 @@ public class ProductCodeAutoCompleteProvider: IAutoCompleteProvider
     public async ValueTask<IEnumerable<DiscordAutoCompleteChoice>> AutoCompleteAsync(AutoCompleteContext context)
     {
         await using var db = await ThumbnailDb.OpenReadAsync().ConfigureAwait(false);
+        db.WithNoCase();
         IEnumerable<(string code, string title)> result;
         if (context.UserInput is not { Length: > 0 } prefix)
         {

--- a/CompatBot/Commands/AutoCompleteProviders/WarningAutoCompleteProvider.cs
+++ b/CompatBot/Commands/AutoCompleteProviders/WarningAutoCompleteProvider.cs
@@ -22,6 +22,7 @@ public class WarningAutoCompleteProvider: IAutoCompleteProvider
                 : w => !w.Retracted && w.DiscordId == userId;
         
         await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
+        db.WithNoCase();
         List<Warning> result;
         if (context.UserInput is not { Length: > 0 } prefix)
             result = await db.Warning

--- a/CompatBot/Database/Migrations/ThumbnailDb/20250806100313_AddNoCaseCollationForGameTitle.Designer.cs
+++ b/CompatBot/Database/Migrations/ThumbnailDb/20250806100313_AddNoCaseCollationForGameTitle.Designer.cs
@@ -2,6 +2,7 @@
 using CompatBot.Database;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -9,9 +10,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace CompatBot.Migrations
 {
     [DbContext(typeof(ThumbnailDb))]
-    partial class ThumbnailDbModelSnapshot : ModelSnapshot
+    [Migration("20250806100313_AddNoCaseCollationForGameTitle")]
+    partial class AddNoCaseCollationForGameTitle
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.7");

--- a/CompatBot/Database/Migrations/ThumbnailDb/20250806100313_AddNoCaseCollationForGameTitle.cs
+++ b/CompatBot/Database/Migrations/ThumbnailDb/20250806100313_AddNoCaseCollationForGameTitle.cs
@@ -1,0 +1,38 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace CompatBot.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddNoCaseCollationForGameTitle : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "name",
+                table: "thumbnail",
+                type: "TEXT",
+                nullable: true,
+                collation: "NOCASE",
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "name",
+                table: "thumbnail",
+                type: "TEXT",
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "TEXT",
+                oldNullable: true,
+                oldCollation: "NOCASE");
+        }
+    }
+}

--- a/CompatBot/Program.cs
+++ b/CompatBot/Program.cs
@@ -35,7 +35,16 @@ internal static class Program
 
         //AppDomain.CurrentDomain.SetData("REGEX_DEFAULT_MATCH_TIMEOUT", TimeSpan.FromMilliseconds(100));
         Regex.CacheSize = 200; // default is 15, we need more for content filter
-        
+
+
+        try
+        {
+            Console.OutputEncoding = Encoding.UTF8;
+        }
+        catch (Exception e)
+        {
+            Config.Log.Warn(e, "Failed to set console output encoding");
+        }
         Console.WriteLine("Confinement: " + SandboxDetector.Detect());
         if (args.Length > 0 && args[0] == "--dry-run")
         {

--- a/CompatBot/Utils/Extensions/BotDbExtensions.cs
+++ b/CompatBot/Utils/Extensions/BotDbExtensions.cs
@@ -1,4 +1,6 @@
 ﻿using CompatBot.Database;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
 
 namespace CompatBot.Utils;
 
@@ -15,5 +17,13 @@ internal static class BotDbExtensions
         if (result && filter.Actions.HasFlag(FilterAction.ShowExplain))
             result = !string.IsNullOrEmpty(filter.ExplainTerm);
         return result;
+    }
+
+    public static T WithNoCase<T>(this T ctx) where T: DbContext
+    {
+        var connection = (SqliteConnection)ctx.Database.GetDbConnection();
+        connection.CreateCollation("NOCASE", (x, y) => string.Compare(x, y, StringComparison.OrdinalIgnoreCase));
+        connection.CreateFunction("instr", (string x, string y) => x.Contains(y, StringComparison.OrdinalIgnoreCase), isDeterministic: true);
+        return ctx;
     }
 }

--- a/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.cs
+++ b/CompatBot/Utils/ResultFormatters/LogParserResultFormatter.cs
@@ -1067,8 +1067,18 @@ internal static partial class LogParserResult
         if (release.Contains("-artix", StringComparison.OrdinalIgnoreCase))
             return "Artix " + kernelVersion;
 
+        if (release.Contains("-clear", StringComparison.OrdinalIgnoreCase))
+            return "Clear Linux " + kernelVersion;
+
+        if (release.Contains("-Unraid", StringComparison.OrdinalIgnoreCase))
+            return "Unraid " + kernelVersion;
+
         if (release.Contains("-cachyos", StringComparison.OrdinalIgnoreCase))
             return "CachyOS " + kernelVersion;
+
+        if (release.Contains("-chos1", StringComparison.OrdinalIgnoreCase)
+            || release.Contains("-chimeraos", StringComparison.OrdinalIgnoreCase))
+            return "ChimeraOS " + kernelVersion;
 
         if (release.Contains(".fc"))
         {


### PR DESCRIPTION
Some providers are using substring search in sqlite, which was broken due to implementation details and non-obvious behavior both on ef core, and sqlite side.

This makes the search case-insensitive.

Also fixes language code to country flag mapping logic for product code embeds by using region information from the product code.