### PR TITLE
Check for executable files

### DIFF
--- a/CompatBot/EventHandlers/LogParsing/ArchiveHandlers/PlainText.cs
+++ b/CompatBot/EventHandlers/LogParsing/ArchiveHandlers/PlainText.cs
@@ -14,6 +14,9 @@ internal sealed class PlainTextHandler: IArchiveHandler
     public Result CanHandle(string fileName, int fileSize, ReadOnlySpan<byte> header)
     {
         LogSize = fileSize;
+        if (fileName.HasExecutableExtension())
+            return Result.Failure().WithCode("executable");
+
         if (fileName.Contains("tty.log", StringComparison.InvariantCultureIgnoreCase))
             return Result.Failure();
 

--- a/CompatBot/EventHandlers/LogParsing/ArchiveHandlers/RarHandler.cs
+++ b/CompatBot/EventHandlers/LogParsing/ArchiveHandlers/RarHandler.cs
@@ -17,11 +17,19 @@ internal sealed class RarHandler: IArchiveHandler
     public Result CanHandle(string fileName, int fileSize, ReadOnlySpan<byte> header)
     {
         if (header.Length >= Header.Length && header[..Header.Length].SequenceEqual(Header)
-            || header.Length == 0 && fileName.EndsWith(".rar", StringComparison.InvariantCultureIgnoreCase))
+            || header is [] && fileName.EndsWith(".rar", StringComparison.InvariantCultureIgnoreCase))
         {
             var firstEntry = Encoding.ASCII.GetString(header);
             if (!firstEntry.Contains(".log", StringComparison.InvariantCultureIgnoreCase))
+            {
+                var idx = -1;
+                while ((idx = firstEntry.IndexOf('.', idx + 1)) > -1 && idx < firstEntry.Length - 4)
+                {
+                    if (firstEntry[idx..(idx + 4)].ToLower().HasExecutableExtension())
+                        return Result.Failure().WithCode("executable");
+                }
                 return Result.Failure().WithMessage("Archive doesn't contain any logs.");
+            }
             return Result.Success();
         }
         return Result.Failure();

--- a/CompatBot/EventHandlers/LogParsing/ArchiveHandlers/ZipHandler.cs
+++ b/CompatBot/EventHandlers/LogParsing/ArchiveHandlers/ZipHandler.cs
@@ -22,7 +22,15 @@ internal sealed class ZipHandler: IArchiveHandler
         {
             var firstEntry = Encoding.ASCII.GetString(header);
             if (!firstEntry.Contains(".log", StringComparison.InvariantCultureIgnoreCase))
+            {
+                var idx = -1;
+                while ((idx = firstEntry.IndexOf('.', idx + 1)) > -1 && idx < firstEntry.Length - 4)
+                {
+                    if (firstEntry[idx..(idx + 4)].ToLower().HasExecutableExtension())
+                        return Result.Failure().WithCode("executable");
+                }
                 return Result.Failure().WithMessage("Archive doesn't contain any logs.");
+            }
             return Result.Success();
         }
         return Result.Failure();

--- a/CompatBot/EventHandlers/LogParsing/SourceHandlers/DiscordAttachmentHandler.cs
+++ b/CompatBot/EventHandlers/LogParsing/SourceHandlers/DiscordAttachmentHandler.cs
@@ -28,7 +28,7 @@ internal sealed class DiscordAttachmentHandler : BaseSourceHandler
                         var result = handler.CanHandle(attachment.FileName, attachment.FileSize, buf.AsSpan(0, read));
                         if (result.IsSuccess())
                             return Result.Success<ISource>(new DiscordAttachmentSource(attachment, handler, attachment.FileName, attachment.FileSize));
-                        else if (result.Message is {Length: >0})
+                        else if (result is {Code.Length: >0} or {Message.Length: >0} )
                             return result.Cast<ISource>();
                     }
                 }

--- a/CompatBot/EventHandlers/LogParsing/SourceHandlers/DropboxHandler.cs
+++ b/CompatBot/EventHandlers/LogParsing/SourceHandlers/DropboxHandler.cs
@@ -56,7 +56,7 @@ internal sealed partial class DropboxHandler : BaseSourceHandler
                         var result = handler.CanHandle(filename, filesize, buf.AsSpan(0, read));
                         if (result.IsSuccess())
                             return Result.Success<ISource>(new DropboxSource(uri, handler, filename, filesize));
-                        else if (result.Message is {Length: >0})
+                        else if (result is {Code.Length: >0} or {Message.Length: >0} )
                             return result.Cast<ISource>();
                     }
                 }

--- a/CompatBot/EventHandlers/LogParsing/SourceHandlers/GenericLinkHandler.cs
+++ b/CompatBot/EventHandlers/LogParsing/SourceHandlers/GenericLinkHandler.cs
@@ -55,7 +55,7 @@ internal sealed partial class GenericLinkHandler : BaseSourceHandler
                         var result = handler.CanHandle(filename, filesize, buf.AsSpan(0, read));
                         if (result.IsSuccess())
                             return Result.Success<ISource>(new GenericSource(uri, handler, host, filename, filesize));
-                        else if (result.Message is {Length: > 0})
+                        else if (result is {Code.Length: >0} or {Message.Length: >0} )
                             return result.Cast<ISource>();
                     }
                 }

--- a/CompatBot/EventHandlers/LogParsing/SourceHandlers/GoogleDriveHandler.cs
+++ b/CompatBot/EventHandlers/LogParsing/SourceHandlers/GoogleDriveHandler.cs
@@ -57,7 +57,7 @@ internal sealed partial class GoogleDriveHandler: BaseSourceHandler
                         var result = handler.CanHandle(fileMeta.Name, (int)fileMeta.Size, buf.AsSpan(0, read));
                         if (result.IsSuccess())
                             return Result.Success<ISource>(new GoogleDriveSource(client, fileInfoRequest, fileMeta, handler));
-                        else if (result.Message is {Length: >0})
+                        else if (result is {Code.Length: >0} or {Message.Length: >0} )
                             return result.Cast<ISource>();
                     }
                 }

--- a/CompatBot/EventHandlers/LogParsing/SourceHandlers/MediafireHandler.cs
+++ b/CompatBot/EventHandlers/LogParsing/SourceHandlers/MediafireHandler.cs
@@ -61,7 +61,7 @@ internal sealed partial class MediafireHandler : BaseSourceHandler
                         var result = handler.CanHandle(filename, filesize, buf.AsSpan(0, read));
                         if (result.IsSuccess())
                             return Result.Success<ISource>(new MediafireSource(directLink, handler, filename, filesize));
-                        else if (result.Message is {Length: >0})
+                        else if (result is {Code.Length: >0} or {Message.Length: >0} )
                             return result.Cast<ISource>();
                     }
                     Config.Log.Debug("MediaFire Response:\n" + Encoding.UTF8.GetString(buf, 0, read));

--- a/CompatBot/EventHandlers/LogParsing/SourceHandlers/MegaHandler.cs
+++ b/CompatBot/EventHandlers/LogParsing/SourceHandlers/MegaHandler.cs
@@ -47,7 +47,7 @@ internal sealed partial class MegaHandler : BaseSourceHandler
                         var result = handler.CanHandle(node.Name, (int)node.Size, buf.AsSpan(0, read));
                         if (result.IsSuccess())
                             return Result.Success<ISource>(new MegaSource(client, uri, node, handler));
-                        else if (result.Message is {Length: >0})
+                        else if (result is {Code.Length: >0} or {Message.Length: >0} )
                             return result.Cast<ISource>();
                     }
                 }

--- a/CompatBot/EventHandlers/LogParsing/SourceHandlers/OneDriveSourceHandler.cs
+++ b/CompatBot/EventHandlers/LogParsing/SourceHandlers/OneDriveSourceHandler.cs
@@ -47,7 +47,7 @@ internal sealed partial class OneDriveSourceHandler : BaseSourceHandler
                             var result = handler.CanHandle(filename, filesize, buf.AsSpan(0, read));
                             if (result.IsSuccess())
                                 return Result.Success<ISource>(new OneDriveSource(uri, handler, filename, filesize));
-                            else if (result.Message is {Length: >0})
+                            else if (result is {Code.Length: >0} or {Message.Length: >0} )
                                 return result.Cast<ISource>();
                         }
                     }

--- a/CompatBot/EventHandlers/LogParsing/SourceHandlers/PastebinHandler.cs
+++ b/CompatBot/EventHandlers/LogParsing/SourceHandlers/PastebinHandler.cs
@@ -41,7 +41,7 @@ internal sealed partial class PastebinHandler : BaseSourceHandler
                         var result = handler.CanHandle(filename, filesize, buf.AsSpan(0, read));
                         if (result.IsSuccess())
                             return Result.Success<ISource>(new PastebinSource(uri, filename, filesize, handler));
-                        else if (result.Message is {Length: >0})
+                        else if (result is {Code.Length: >0} or {Message.Length: >0} )
                             return result.Cast<ISource>();
                     }
                 }

--- a/CompatBot/EventHandlers/LogParsing/SourceHandlers/YandexDiskHandler.cs
+++ b/CompatBot/EventHandlers/LogParsing/SourceHandlers/YandexDiskHandler.cs
@@ -53,7 +53,7 @@ internal sealed partial class YandexDiskHandler: BaseSourceHandler
                         var result = handler.CanHandle(filename, filesize, buf.AsSpan(0, read));
                         if (result.IsSuccess())
                             return Result.Success<ISource>(new YaDiskSource(resourceInfo.File, handler, filename, filesize));
-                        else if (result.Message is {Length: >0})
+                        else if (result is {Code.Length: >0} or {Message.Length: >0} )
                             return result.Cast<ISource>();
                     }
                 }

--- a/CompatBot/EventHandlers/LogParsingHandler.cs
+++ b/CompatBot/EventHandlers/LogParsingHandler.cs
@@ -56,6 +56,7 @@ public static class LogParsingHandler
         if (message.Author.IsBotSafeCheck())
             return Task.CompletedTask;
         
+        /*
         if (!args.Channel.IsPrivate
             && !Config.Moderation.LogParsingChannels.Contains(args.Channel.Id))
             return Task.CompletedTask;
@@ -64,6 +65,7 @@ public static class LogParsingHandler
             && (message.Content.StartsWith(Config.CommandPrefix)
                 || message.Content.StartsWith(Config.AutoRemoveCommandPrefix)))
             return Task.CompletedTask;
+        */
 
         var isSpamChannel = args.Channel.IsSpamChannel();
         var isHelpChannel = args.Channel.IsHelpChannel();
@@ -88,7 +90,8 @@ public static class LogParsingHandler
                 .Select(async (ISourceHandler h, CancellationToken _) => await h.FindHandlerAsync(message, ArchiveHandlers).ConfigureAwait(false))
                 .ToList();
             using var source = possibleHandlers.FirstOrDefault(h => h.IsSuccess())?.Data;
-            var fail = possibleHandlers.FirstOrDefault(h => h is {Message.Length: >0})?.Message;
+            var fail = possibleHandlers.FirstOrDefault(h => h is { Code.Length: > 0 })
+                       ?? possibleHandlers.FirstOrDefault(h => h is { Message.Length: > 0 });
             foreach (var h in possibleHandlers)
             {
                 if (ReferenceEquals(h.Data, source))
@@ -314,11 +317,29 @@ public static class LogParsingHandler
                         Config.Log.Debug($"<<<<<<< {message.Id % 100} Finished parsing in {startTime.Elapsed}");
                 }
             }
-            if (!string.IsNullOrEmpty(fail)
+            if (fail is { Code: "executable"} && !await message.Author.IsWhitelistedAsync(client, message.Channel?.Guild).ConfigureAwait(false))
+            {
+                await ContentFilter.PerformFilterActions(
+                    client,
+                    message,
+                    new()
+                    {
+                        Id = -1,
+                        String = fail.Code,
+                        Context = FilterContext.Chat,
+                        Actions = FilterAction.RemoveContent | FilterAction.SendMessage,
+                        CustomMessage = "Uploading executable files is not allowed",
+                    },
+                    infraction: "🦠 Attachment with executable file",
+                    warningReason: "Potential malware"
+                ).ConfigureAwait(false);
+                return;
+            }
+            if (fail is {Message: {Length: >0 } failMsg} 
                 && (isHelpChannel || isSpamChannel))
             {
                 Config.TelemetryClient?.TrackRequest(nameof(LogParsingHandler), start, DateTimeOffset.UtcNow - start, HttpStatusCode.InternalServerError.ToString(), false);
-                await channel.SendMessageAsync($"{message.Author.Mention} {fail}").ConfigureAwait(false);
+                await channel.SendMessageAsync($"{message.Author?.Mention} {failMsg}").ConfigureAwait(false);
                 return;
             }
 
@@ -328,7 +349,7 @@ public static class LogParsingHandler
                 case "TXT":
                 {
                     await channel.SendMessageAsync(
-                        $"{message.Author.Mention}, please upload the full RPCS3.log.gz (or RPCS3.log with a zip/rar icon) file " +
+                        $"{message.Author?.Mention}, please upload the full RPCS3.log.gz (or RPCS3.log with a zip/rar icon) file " +
                         "after closing the emulator instead of copying the logs from RPCS3's interface, " +
                         "as it doesn't contain all the required information."
                     ).ConfigureAwait(false);

--- a/CompatBot/Utils/PathUtils.cs
+++ b/CompatBot/Utils/PathUtils.cs
@@ -20,4 +20,24 @@ public static class PathUtils
         result.Reverse();
         return result.ToArray();
     }
+
+    public static bool HasExecutableExtension(this string? filename)
+    {
+        if (filename is not { Length: > 0 })
+            return false;
+        
+        return Path.GetExtension(filename).ToLower() switch
+        {
+            ".exe" or
+            ".bat" or
+            ".cmd" or
+            ".ps1" or
+            ".com" or
+            ".vbs" or
+            ".lnk" or
+            ".url" or
+            ".sh" => true,
+            _ => false
+        };
+    }
 }


### PR DESCRIPTION
Rudimentary checks for executable files inside archives to prevent bots spreading malware