### PR TITLE
Support application command mentions in explanation text

### DIFF
--- a/CompatBot/Commands/Explain.cs
+++ b/CompatBot/Commands/Explain.cs
@@ -1,8 +1,4 @@
-﻿using System.Globalization;
-using System.IO;
-using System.Net.Http;
-using System.Runtime.InteropServices;
-using CompatApiClient.Compression;
+﻿using CompatApiClient.Compression;
 using CompatApiClient.Utils;
 using CompatBot.Commands.AutoCompleteProviders;
 using CompatBot.Database;
@@ -10,6 +6,11 @@ using CompatBot.Database.Providers;
 using DSharpPlus.Interactivity;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using ResultNet;
+using System.Globalization;
+using System.IO;
+using System.Net.Http;
+using System.Runtime.InteropServices;
 
 namespace CompatBot.Commands;
 
@@ -42,7 +43,7 @@ internal static class Explain
         if (to is null)
         {
             if (result.explanation.Text is {Length: >0})
-                explainMsg.WithContent(result.explanation.Text);
+                explainMsg.WithContent(await result.explanation.FormatTextAsync(ctx.Client).ConfigureAwait(false));
         }
         else
         {
@@ -50,7 +51,7 @@ internal static class Explain
             explainMsg.WithContent(
                 $"""
                  {to.Mention} please read the explanation for `{result.explanation.Keyword.Sanitize(replaceBackTicks: true)}`:
-                 {result.explanation.Text}
+                 {await result.explanation.FormatTextAsync(ctx.Client).ConfigureAwait(false)}
                  """
             );
             if (canPing)
@@ -438,7 +439,13 @@ internal static class Explain
         return (explanation, fuzzyMatch, coefficient);
     }
 
-    internal static async ValueTask<bool> SendExplanationAsync((Explanation? explanation, string? fuzzyMatch, double score) termLookupResult, string term, DiscordMessage sourceMessage, bool useReply, bool ping = false)
+    internal static async ValueTask<bool> SendExplanationAsync(
+        (Explanation? explanation, string? fuzzyMatch, double score) termLookupResult,
+        string term,
+        DiscordClient client,
+        DiscordMessage sourceMessage,
+        bool useReply,
+        bool ping = false)
     {
         try
         {
@@ -465,7 +472,7 @@ internal static class Explain
                 StatsStorage.IncExplainStat(explain.Keyword);
                 msgBuilder = new();
                 if (explain.Text is {Length: >0})
-                    msgBuilder.WithContent(explain.Text);
+                    msgBuilder.WithContent(await explain.FormatTextAsync(client).ConfigureAwait(false));
                 if (!usedReply && useReply)
                     msgBuilder.WithReply(sourceMessage.Id, ping);
                 if (ping)

--- a/CompatBot/Commands/MessageMenuCommands.cs
+++ b/CompatBot/Commands/MessageMenuCommands.cs
@@ -59,7 +59,7 @@ internal static class MessageMenuCommands
         ).ConfigureAwait(false);
         var canPing = ModProvider.IsMod(ctx.User.Id);
         var term = ((TextInputModalSubmission)value).Value;
-        await Explain.SendExplanationAsync(result, term, replyTo, true, canPing).ConfigureAwait(false);
+        await Explain.SendExplanationAsync(result, term, ctx.Client, replyTo, true, canPing).ConfigureAwait(false);
     }
 
     // non-whitenames can use these

--- a/CompatBot/Database/Providers/ContentFilter.cs
+++ b/CompatBot/Database/Providers/ContentFilter.cs
@@ -243,7 +243,7 @@ internal static class ContentFilter
             && trigger.ExplainTerm is { Length: >0 } term)
         {
             var result = await Explain.LookupTerm(term).ConfigureAwait(false);
-            await Explain.SendExplanationAsync(result, term, message, true).ConfigureAwait(false);
+            await Explain.SendExplanationAsync(result, term, client, message, true).ConfigureAwait(false);
         }
 
         if (trigger.Actions.HasFlag(FilterAction.Kick)

--- a/CompatBot/EventHandlers/Greeter.cs
+++ b/CompatBot/EventHandlers/Greeter.cs
@@ -5,13 +5,14 @@ namespace CompatBot.EventHandlers;
 
 internal static class Greeter
 {
-    public static async Task OnMemberAdded(DiscordClient _, GuildMemberAddedEventArgs args)
+    public static async Task OnMemberAdded(DiscordClient client, GuildMemberAddedEventArgs args)
     {
         await using var db = await BotDb.OpenReadAsync().ConfigureAwait(false);
         if (await db.Explanation.FirstOrDefaultAsync(e => e.Keyword == "motd").ConfigureAwait(false) is {Text.Length: >0} explanation)
         {
             var dm = await args.Member.CreateDmChannelAsync().ConfigureAwait(false);
-            await dm.SendMessageAsync(explanation.Text, explanation.Attachment, explanation.AttachmentFilename).ConfigureAwait(false);
+            var msg = await explanation.FormatTextAsync(client).ConfigureAwait(false);
+            await dm.SendMessageAsync(msg, explanation.Attachment, explanation.AttachmentFilename).ConfigureAwait(false);
             Config.Log.Info($"Sent motd to {args.Member.GetMentionWithNickname()}");
         }
     }

--- a/CompatBot/EventHandlers/LogAsTextMonitor.cs
+++ b/CompatBot/EventHandlers/LogAsTextMonitor.cs
@@ -7,7 +7,7 @@ internal static partial class LogAsTextMonitor
     [GeneratedRegex(@"^[`""]?(·|(\w|!)) ({(rsx|PPU|SPU)|LDR:)|E LDR:", RegexOptions.IgnoreCase | RegexOptions.Multiline)]
     private static partial Regex LogLine();
 
-    public static async Task OnMessageCreated(DiscordClient _, MessageCreatedEventArgs args)
+    public static async Task OnMessageCreated(DiscordClient client, MessageCreatedEventArgs args)
     {
         if (DefaultHandlerFilter.IsFluff(args.Message))
             return;
@@ -26,20 +26,25 @@ internal static partial class LogAsTextMonitor
             {
                 brokenDump = true;
                 if (args.Message.Content.Contains("fs::file is null"))
-                    msg = $"{args.Message.Author.Mention} this error usually indicates a missing `.rap` license file.\n";
+                    msg = $"{args.Message.Author!.Mention} this error usually indicates a missing `.rap` license file.\n";
                 else if (args.Message.Content.Contains("Invalid or unsupported file format"))
-                    msg = $"{args.Message.Author.Mention} this error usually indicates an encrypted or corrupted game dump.\n";
+                    msg = $"{args.Message.Author!.Mention} this error usually indicates an encrypted or corrupted game dump.\n";
                 else
                     brokenDump = false;
             }
             var logUploadExplain = await PostLogHelpHandler.GetExplanationAsync("log").ConfigureAwait(false);
+            var logUploadTxt = await logUploadExplain.FormatTextAsync(client).ConfigureAwait(false);
             if (brokenDump)
-                msg += "Please follow the quickstart guide to get a proper dump of a digital title.\n" +
-                       "Also please upload the full RPCS3 log instead of pasting only a section which may be completely irrelevant.\n" +
-                       logUploadExplain.Text;
+                msg += $"""
+                    Please follow the quickstart guide to get a proper dump of a digital title.
+                    Also please upload the full RPCS3 log instead of pasting only a section which may be completely irrelevant.
+                    {logUploadTxt}
+                    """;
             else
-                msg = $"{args.Message.Author.Mention} please upload the full RPCS3 log instead of pasting only a section which may be completely irrelevant." +
-                      logUploadExplain.Text;
+                msg = $"""
+                    {args.Message.Author!.Mention} please upload the full RPCS3 log instead of pasting only a section which may be completely irrelevant.
+                    {logUploadTxt}
+                    """;
             await args.Channel.SendMessageAsync(msg, logUploadExplain.Attachment, logUploadExplain.AttachmentFilename).ConfigureAwait(false);
         }
     }

--- a/CompatBot/EventHandlers/PostLogHelpHandler.cs
+++ b/CompatBot/EventHandlers/PostLogHelpHandler.cs
@@ -20,7 +20,7 @@ internal static partial class PostLogHelpHandler
     };
     private static DateTime lastMention = DateTime.UtcNow.AddHours(-1);
 
-    public static async Task OnMessageCreated(DiscordClient _, MessageCreatedEventArgs args)
+    public static async Task OnMessageCreated(DiscordClient client, MessageCreatedEventArgs args)
     {
         if (DefaultHandlerFilter.IsFluff(args.Message))
             return;
@@ -41,13 +41,14 @@ internal static partial class PostLogHelpHandler
         try
         {
             var explanation = await GetExplanationAsync(string.IsNullOrEmpty(match.Groups["vulkan"].Value) ? "log" : "vulkan-1").ConfigureAwait(false);
+            var explainContent = await explanation.FormatTextAsync(client).ConfigureAwait(false);
             var lastBotMessages = await args.Channel.GetMessagesBeforeCachedAsync(args.Message.Id, 10).ConfigureAwait(false);
             foreach (var msg in lastBotMessages)
                 if (BotReactionsHandler.NeedToSilence(msg).needToChill
-                    || msg.Author.IsCurrent && msg.Content == explanation.Text)
+                    || msg.Author!.IsCurrent && msg.Content == explainContent)
                     return;
 
-            await args.Channel.SendMessageAsync(explanation.Text, explanation.Attachment, explanation.AttachmentFilename).ConfigureAwait(false);
+            await args.Channel.SendMessageAsync(explainContent, explanation.Attachment, explanation.AttachmentFilename).ConfigureAwait(false);
             lastMention = DateTime.UtcNow;
         }
         finally

--- a/CompatBot/Utils/ExplanationFormatter.cs
+++ b/CompatBot/Utils/ExplanationFormatter.cs
@@ -1,0 +1,37 @@
+﻿using CompatBot.Database;
+using System.Text.RegularExpressions;
+
+namespace CompatBot.Utils;
+
+internal static partial class ExplanationFormatter
+{
+    [GeneratedRegex(@"</(?<name>(\w|\s)+)(:\d+)?>", RegexOptions.IgnoreCase | RegexOptions.ExplicitCapture)]
+    private static partial Regex CmdMention();
+
+    public static async ValueTask<string> FormatTextAsync(this Explanation explanation, DiscordClient client)
+    {
+        if (explanation is not { Text: {Length: >0} result })
+            return "";
+
+        var matches = CmdMention().Matches(result).Select((Match m) => (m.Value, m.Groups["name"].Value)).Distinct().ToList();
+        foreach (var (substr, name) in matches)
+        {
+            try
+            {
+                var nameParts = name.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+                if (await client.GetGlobalApplicationCommandAsync(nameParts[0]).ConfigureAwait(false) is { } cmd)
+                {
+                    var mention = nameParts is [_]
+                        ? cmd.Mention
+                        : cmd.GetSubcommandMention(nameParts[1..]);
+                    result = result.Replace(substr, mention, StringComparison.OrdinalIgnoreCase);
+                }
+            }
+            catch
+            {
+                continue;
+            }
+        }
+        return result;
+    }
+}


### PR DESCRIPTION
You can insert application command mentions with simplified syntax, e.g.:
```
Use command </psn check updates> to search for game updates.
```

Full command references are also supported and will be updated with correct command id if needed, e.g.:
```
Use command </explain show:1355958880395460702> to read explanations.
```
